### PR TITLE
infra: reproducible Grafana monitoring at /grafana + app metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ Internet → Cloudflare → Nginx (TLS, static files) → FastAPI (:8001, localh
   build served by Nginx. Dev server on port **3121**.
 - **Reverse proxy** - Nginx handles TLS termination, security headers, serves
   the static frontend build, and proxies `/api/` to the Python backend.
-- **Monitoring** - Prometheus (9090), Grafana (3002), Node Exporter (9100). Optional.
+- **Monitoring** (optional) - Prometheus + Node Exporter + Blackbox + Grafana,
+  all bound to 127.0.0.1; Grafana served via Nginx at `/grafana/`. See `infra/grafana/`.
 
 ---
 
@@ -207,8 +208,10 @@ Manual redeploy: `git pull && sudo bash infra/setup-vps.sh`
    `127.0.0.1:8001`. Only Nginx talks to it.
 2. **Never commit secrets**, API keys, or `.env` files. Use `.env.local`
    (gitignored) for local config.
-3. **Monitoring ports** (Prometheus 9090, Grafana 3002) should be IP-restricted
-   in production via UFW - they are open by default for ease of setup.
+3. **Monitoring stays localhost-only.** Prometheus (9090), Node Exporter (9100),
+   Blackbox (9115) and Grafana (3002) all bind to `127.0.0.1`; `setup-vps.sh`
+   keeps those ports off the public firewall. Grafana is reached only through the
+   Nginx reverse proxy at `/grafana/`. See `infra/grafana/`.
 4. **Always use HTTPS** in production. The Nginx config redirects HTTP→HTTPS.
 5. **CSP headers** are set in `nginx-vedicpanchanga.conf`. If adding new
    third-party scripts/analytics, update the Content-Security-Policy header.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.128.8
 uvicorn==0.39.0
+prometheus-fastapi-instrumentator==7.1.0
 pyswisseph==2.10.3.2
 pytz==2026.1.post1
 timezonefinder==8.2.0

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 from dotenv import load_dotenv
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
+from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel, Field
 from starlette.middleware.cors import CORSMiddleware
 
@@ -46,8 +47,8 @@ def health():
     the process is up and the Swiss Ephemeris data directory is present. Returns
     503 + status "degraded" if the .se1 files are missing, since calculations
     silently fail without them (see CLAUDE.md). Reached publicly at
-    https://vedicpanchanga.com/api/health (the /api/ nginx proxy); note /health
-    itself is reverse-proxied to Grafana, so app health lives under /api.
+    https://vedicpanchanga.com/api/health (the /api/ nginx proxy). The Grafana
+    monitoring UI lives under /grafana, so app health stays under /api.
     """
     ephe_dir = ROOT_DIR / "ephe"
     ephe_ok = ephe_dir.is_dir() and next(ephe_dir.glob("*.se1"), None) is not None
@@ -459,3 +460,11 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# Prometheus application metrics. Exposed at /metrics (not under /api, so Nginx
+# does not proxy it - Prometheus scrapes it directly on 127.0.0.1:8001, keeping
+# it off the public internet). Powers the "Application performance" rows of the
+# Grafana dashboard (request rate, latency percentiles, error rate, by endpoint).
+Instrumentator(excluded_handlers=["/metrics"]).instrument(app).expose(
+    app, endpoint="/metrics", include_in_schema=False
+)

--- a/infra/README.md
+++ b/infra/README.md
@@ -19,7 +19,8 @@ Nginx :80 -> 301 -> :443 (TLS 1.2/1.3, HSTS, real-IP from CF, X-Frame-Options,
     |
     |-- /assets/   -> /apps/panchanga/frontend/dist/assets/  (1y immutable cache)
     |-- /          -> try_files $uri $uri/ /index.html       (SPA fallback)
-    |-- /health/   -> proxy -> http://127.0.0.1:3002         (Grafana UI)
+    |-- /grafana/  -> proxy -> http://127.0.0.1:3002         (Grafana UI)
+    |-- /health    -> proxy -> http://127.0.0.1:8001/api/health  (app health)
     +-- /api/      -> proxy -> http://127.0.0.1:8001/api/     (FastAPI)
                                        |     (incl. GET /api/health probe)
                                        v
@@ -28,12 +29,13 @@ Nginx :80 -> 301 -> :443 (TLS 1.2/1.3, HSTS, real-IP from CF, X-Frame-Options,
                               bound to 127.0.0.1 - never exposed
 ```
 
-> `/health/` is the **Grafana** monitoring UI, not an app health check. The
-> application's own readiness probe is `GET /api/health`
-> (<https://vedicpanchanga.com/api/health>): 200 when the Swiss Ephemeris data
-> is present, 503 otherwise. The exporters (Prometheus 9090, Node Exporter
-> 9100, Blackbox 9115) and Grafana (3002) all bind to 127.0.0.1; only Grafana
-> is reachable, and only via the `/health/` proxy. See [`grafana/`](grafana/).
+> `/grafana/` is the **Grafana** monitoring UI. The application's own readiness
+> probe is `GET /api/health`, also exposed at `/health`
+> (<https://vedicpanchanga.com/health>): 200 when the Swiss Ephemeris data is
+> present, 503 otherwise. The exporters (Prometheus
+> 9090, Node Exporter 9100, Blackbox 9115) and Grafana (3002) all bind to
+> 127.0.0.1; only Grafana is reachable, and only via the `/grafana/` proxy. See
+> [`grafana/`](grafana/).
 
 ## Scripts
 
@@ -61,7 +63,7 @@ What it does, in order:
    `/etc/ssl/cloudflare/origin.{pem,key}` exist.
 6. **Firewall (UFW)** - opens `22/80/443`; blocks `8000/8001` directly; and
    drops any public allow on the monitoring ports `3002/9090/9100/9115` (they
-   stay localhost-only; Grafana is reached through the `/health/` proxy).
+   stay localhost-only; Grafana is reached through the `/grafana/` proxy).
 7. **Systemd** - enables and restarts `panchanga-backend` + `nginx`.
 
 ### Cloudflare Origin Certificate
@@ -98,10 +100,10 @@ sudo bash infra/grafana/install.sh    # idempotent; safe to re-run
 Installs Prometheus (2.53), Node Exporter (1.8.1), Blackbox Exporter (0.25),
 and Grafana, then provisions all of them from the version-controlled files in
 [`grafana/`](grafana/). Everything binds to `127.0.0.1`. Grafana is served only
-through the Nginx `/health/` proxy; the other exporters are reachable only via
+through the Nginx `/grafana/` proxy; the other exporters are reachable only via
 an SSH tunnel. The blackbox job probes `https://vedicpanchanga.com/api/health`
 (end-to-end), the homepage, and the origin backend, surfaced on the
-**Application Monitoring** dashboard (`/health/d/apps-mon/application-monitoring`).
+**Application Monitoring** dashboard (`/grafana/d/apps-mon/application-monitoring`).
 
 ## Common operations
 

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -19,15 +19,18 @@ this folder; the Grafana admin password is never touched.
 
 | Component         | Port | Reachable from outside? |
 |-------------------|------|-------------------------|
-| Grafana           | 3002 | Yes, via Nginx `/health/` proxy only |
+| Grafana           | 3002 | Yes, via Nginx `/grafana/` proxy only |
 | Prometheus        | 9090 | No (SSH tunnel)         |
 | Node Exporter     | 9100 | No (SSH tunnel)         |
 | Blackbox Exporter | 9115 | No (SSH tunnel)         |
 
-Grafana server settings (`root_url=https://vedicpanchanga.com/health/`,
-`serve_from_sub_path`, 127.0.0.1 bind) are applied via a systemd drop-in
-(`/etc/systemd/system/grafana-server.service.d/override.conf`) so the installer
-never rewrites `grafana.ini` and never resets the admin password.
+Grafana `[server]` settings (`root_url=https://vedicpanchanga.com/grafana/`,
+`serve_from_sub_path = true`, `http_addr = 127.0.0.1`) are set idempotently in
+`grafana.ini` by `install.sh` - only those keys are touched, so the admin
+password and everything else are preserved. The matching Nginx rule passes the
+`/grafana/` prefix through unchanged (`proxy_pass http://127.0.0.1:3002;`, no
+trailing slash, no `proxy_redirect`); a trailing slash would strip the prefix
+and Grafana's assets would 404 ("failed to load application files").
 
 ## Layout
 
@@ -48,12 +51,23 @@ grafana/
 UID `apps-mon`, served at:
 
 ```
-https://vedicpanchanga.com/health/d/apps-mon/application-monitoring
+https://vedicpanchanga.com/grafana/d/apps-mon/application-monitoring
 ```
 
-Panels: app up (end-to-end probe of `/api/health` through Cloudflare + Nginx),
-backend up (origin probe), HTTP status, TLS cert days remaining, availability /
-probe-duration / HTTP-phase timeseries, and host CPU / memory / disk.
+Detailed, grouped into rows: **Service health** (status, 24h uptime, response
+time, HTTP status, TLS expiry), **Application performance** (request rate, 5xx
+error rate, latency p50/p90/p95/p99, request rate + p95 latency by endpoint),
+**Availability & latency** (per-target timeseries + status table), **HTTP & TLS
+detail** (status code over time, HTTP phase durations, DNS lookup, redirects,
+content length, HTTPS flag), **Host utilisation** (CPU / memory / disk gauges +
+load average), **Host resources over time** (CPU, memory breakdown, network,
+disk I/O, filesystem-by-mount), and **Host info** (uptime, CPU cores, total
+memory).
+
+The application metrics come from the FastAPI backend, instrumented with
+`prometheus-fastapi-instrumentator` and exposed at `/metrics`. That path is not
+proxied by Nginx, so Prometheus scrapes it directly on `127.0.0.1:8001` and it
+never reaches the public internet.
 
 Blackbox probe targets (defined in `prometheus/prometheus.yml`):
 
@@ -63,7 +77,8 @@ Blackbox probe targets (defined in `prometheus/prometheus.yml`):
 
 > The backend readiness endpoint is `GET /api/health` (returns 200 + `status:ok`
 > when the Swiss Ephemeris data is present, 503 + `status:degraded` otherwise).
-> `/health` itself is the Grafana UI, which is why app health lives under `/api`.
+> The Grafana UI lives under `/grafana/`; the app's health is `/api/health`
+> (also exposed at `/health`).
 
 ## Editing the dashboard
 

--- a/infra/grafana/dashboards/application-monitoring.json
+++ b/infra/grafana/dashboards/application-monitoring.json
@@ -1,14 +1,22 @@
 {
   "uid": "apps-mon",
   "title": "Application Monitoring",
-  "description": "Uptime, latency and host health for vedicpanchanga.com.",
-  "tags": ["vedicpanchanga", "application", "uptime", "blackbox"],
+  "description": "Application performance, uptime, HTTP/TLS detail and host health for vedicpanchanga.com.",
+  "tags": [
+    "vedicpanchanga",
+    "application",
+    "uptime",
+    "blackbox"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 2,
+  "version": 4,
   "editable": true,
   "graphTooltip": 1,
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "refresh": "30s",
   "links": [
     {
@@ -21,10 +29,10 @@
     },
     {
       "title": "Health JSON",
-      "url": "https://vedicpanchanga.com/api/health",
+      "url": "https://vedicpanchanga.com/health",
       "type": "link",
       "icon": "doc",
-      "tooltip": "Raw /api/health response",
+      "tooltip": "Raw /health response",
       "targetBlank": true
     }
   ],
@@ -34,12 +42,19 @@
         "name": "target",
         "label": "Probe target",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
         "query": "label_values(probe_success, instance)",
         "refresh": 2,
         "includeAll": true,
         "multi": true,
-        "current": { "selected": true, "text": "All", "value": "$__all" }
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
       }
     ]
   },
@@ -48,79 +63,155 @@
       "type": "row",
       "title": "Service health",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "panels": []
     },
     {
       "type": "stat",
       "title": "Status",
-      "description": "End-to-end probe of /api/health through Cloudflare + Nginx + backend.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_success{instance=\"https://vedicpanchanga.com/api/health\"}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 } } },
-            { "type": "value", "options": { "1": { "text": "UP", "color": "green", "index": 1 } } }
-          ],
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }]
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
           },
-          "color": { "mode": "thresholds" }
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "center",
         "textMode": "value"
-      }
+      },
+      "description": "End-to-end probe of /api/health through Cloudflare + Nginx + backend."
     },
     {
       "type": "stat",
       "title": "Uptime (24h)",
-      "description": "Share of successful probes over the last 24 hours.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "avg_over_time(probe_success{instance=\"https://vedicpanchanga.com/api/health\"}[24h]) * 100"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percent",
-          "decimals": 2,
-          "min": 0,
-          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 99 },
-              { "color": "green", "value": 99.9 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "unit": "percent",
+          "decimals": 2
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
@@ -130,35 +221,62 @@
     {
       "type": "stat",
       "title": "Response time",
-      "description": "Total blackbox probe duration for the public health URL.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_duration_seconds{instance=\"https://vedicpanchanga.com/api/health\"}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
-          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.5 },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "unit": "s",
+          "decimals": 2
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
@@ -168,33 +286,60 @@
     {
       "type": "stat",
       "title": "HTTP status",
-      "description": "Latest HTTP status code returned to the probe.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 16, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_http_status_code{instance=\"https://vedicpanchanga.com/api/health\"}"
         }
       ],
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 300 },
-              { "color": "red", "value": 400 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 400
+              }
             ]
-          },
-          "color": { "mode": "thresholds" }
+          }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "center",
@@ -204,35 +349,62 @@
     {
       "type": "stat",
       "title": "TLS expires in",
-      "description": "Days until the served TLS certificate expires.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 20, "y": 1 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "(probe_ssl_earliest_cert_expiry{instance=\"https://vedicpanchanga.com/api/health\"} - time()) / 86400"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "d",
-          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 14 },
-              { "color": "green", "value": 30 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "unit": "d",
+          "decimals": 0
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
@@ -241,21 +413,533 @@
     },
     {
       "type": "row",
+      "title": "Application performance",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Requests / sec",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_requests_total[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "textMode": "value"
+      },
+      "description": "Backend request throughput from the FastAPI Prometheus metrics."
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (5xx)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (sum(rate(http_requests_total{status=\"5xx\"}[5m])) or vector(0)) / clamp_min(sum(rate(http_requests_total[5m])), 0.001)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Latency p95",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m])))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 3
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total requests",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(http_requests_total)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
+      },
+      "description": "Cumulative requests since the backend last started."
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency percentiles (overall)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+          "legendFormat": "p90"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate by endpoint",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (handler) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{handler}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency p95 by endpoint",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, handler) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{handler}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "row",
       "title": "Availability & latency",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
       "panels": []
     },
     {
       "type": "timeseries",
       "title": "Availability",
-      "description": "1 = up, 0 = down, per probed target.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_success{instance=~\"$target\"}",
           "legendFormat": "{{instance}}"
@@ -263,35 +947,57 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "min": 0,
-          "max": 1,
           "custom": {
             "drawStyle": "line",
-            "lineInterpolation": "stepAfter",
             "fillOpacity": 25,
             "lineWidth": 2,
-            "spanNulls": false,
-            "gradientMode": "opacity"
+            "gradientMode": "opacity",
+            "lineInterpolation": "stepAfter"
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min"] },
-        "tooltip": { "mode": "multi", "sort": "none" }
-      }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "1 = up, 0 = down."
     },
     {
       "type": "timeseries",
       "title": "Response time by target",
-      "description": "Total probe duration per target.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_duration_seconds{instance=~\"$target\"}",
           "legendFormat": "{{instance}}"
@@ -299,90 +1005,250 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 15,
             "lineWidth": 2,
             "gradientMode": "opacity"
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max", "mean"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       }
     },
     {
       "type": "table",
       "title": "Probe targets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Current status of every monitored endpoint.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_success{instance=~\"$target\"}",
-          "format": "table",
-          "instant": true
+          "instant": true,
+          "format": "table"
         }
       ],
       "transformations": [
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "job": true, "__name__": true, "app": true },
-            "indexByName": { "instance": 0, "scope": 1, "Value": 2 },
-            "renameByName": { "instance": "Target", "scope": "Scope", "Value": "Status" }
+            "excludeByName": {
+              "Time": true,
+              "job": true,
+              "__name__": true,
+              "app": true
+            },
+            "indexByName": {
+              "instance": 0,
+              "scope": 1,
+              "Value": 2
+            },
+            "renameByName": {
+              "instance": "Target",
+              "scope": "Scope",
+              "Value": "Status"
+            }
           }
         }
       ],
       "fieldConfig": {
-        "defaults": { "custom": { "align": "left", "cellOptions": { "type": "auto" } } },
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            }
+          }
+        },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Status" },
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
             "properties": [
-              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
-              { "id": "custom.align", "value": "center" },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
               {
                 "id": "mappings",
                 "value": [
-                  { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 0 } } },
-                  { "type": "value", "options": { "1": { "text": "UP", "color": "green", "index": 1 } } }
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "DOWN",
+                        "color": "red",
+                        "index": 0
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "1": {
+                        "text": "UP",
+                        "color": "green",
+                        "index": 1
+                      }
+                    }
+                  }
                 ]
               },
               {
                 "id": "thresholds",
-                "value": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
               }
             ]
           }
         ]
       },
-      "options": { "showHeader": true, "cellHeight": "sm", "footer": { "show": false } }
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      }
     },
     {
       "type": "row",
-      "title": "HTTP request breakdown",
+      "title": "HTTP & TLS detail",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
       "panels": []
     },
     {
       "type": "timeseries",
-      "title": "HTTP phase durations",
-      "description": "Per-phase latency from the blackbox HTTP prober (DNS, connect, TLS, processing, transfer) for the public health URL.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "title": "HTTP status code over time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "probe_http_status_code{instance=~\"$target\"}",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP phase durations",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "probe_http_duration_seconds{instance=\"https://vedicpanchanga.com/api/health\"}",
           "legendFormat": "{{phase}}"
@@ -390,39 +1256,327 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 20,
-            "lineWidth": 1,
-            "stacking": { "mode": "normal", "group": "A" },
-            "gradientMode": "opacity"
+            "lineWidth": 2,
+            "gradientMode": "opacity",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
           },
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "DNS, connect, TLS, processing, transfer (public health URL)."
+    },
+    {
+      "type": "stat",
+      "title": "DNS lookup",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "probe_dns_lookup_time_seconds{instance=\"https://vedicpanchanga.com/api/health\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 3
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Redirects",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 53
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "probe_http_redirects{instance=\"https://vedicpanchanga.com/api/health\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Content length",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 53
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "probe_http_content_length{instance=\"https://vedicpanchanga.com/api/health\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "HTTPS",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 53
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "probe_http_ssl{instance=\"https://vedicpanchanga.com/api/health\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "No",
+                  "color": "red",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "Yes",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
       }
     },
     {
       "type": "row",
-      "title": "Host resources",
+      "title": "Host - utilisation",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
       "panels": []
     },
     {
       "type": "gauge",
       "title": "CPU busy",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 33 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 59
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)"
         }
@@ -436,17 +1590,34 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 70 },
-              { "color": "red", "value": 90 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       }
@@ -454,12 +1625,23 @@
     {
       "type": "gauge",
       "title": "Memory used",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 33 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 59
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100"
         }
@@ -473,17 +1655,34 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 75 },
-              { "color": "red", "value": 90 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       }
@@ -491,12 +1690,23 @@
     {
       "type": "gauge",
       "title": "Disk used (/)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 33 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 59
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "100 - (node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"tmpfs\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"tmpfs\"} * 100)"
         }
@@ -510,19 +1720,639 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 80 },
-              { "color": "red", "value": 90 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showThresholdLabels": false,
         "showThresholdMarkers": true
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Load average",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 59
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_load1",
+          "legendFormat": "1m"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_load5",
+          "legendFormat": "5m"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_load15",
+          "legendFormat": "15m"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Host - resources over time",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU usage %",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 - (avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "legendFormat": "cpu busy %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Memory breakdown",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 67
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - node_memory_Buffers_bytes - node_memory_Cached_bytes",
+          "legendFormat": "used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_Buffers_bytes",
+          "legendFormat": "buffers"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_Cached_bytes",
+          "legendFormat": "cached"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemFree_bytes",
+          "legendFormat": "free"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "lineWidth": 2,
+            "gradientMode": "opacity",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Network traffic",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_network_receive_bytes_total{device!=\"lo\"}[5m])",
+          "legendFormat": "{{device}} rx"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_network_transmit_bytes_total{device!=\"lo\"}[5m])",
+          "legendFormat": "{{device}} tx"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Disk I/O",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_disk_read_bytes_total[5m])",
+          "legendFormat": "{{device}} read"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_disk_written_bytes_total[5m])",
+          "legendFormat": "{{device}} write"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "gradientMode": "opacity"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Filesystem usage by mount",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"} * 100)",
+          "legendFormat": "{{mountpoint}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      }
+    },
+    {
+      "type": "row",
+      "title": "Host info",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 87
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "System uptime",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 88
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_time_seconds - node_boot_time_seconds"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "CPU cores",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 88
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count(count(node_cpu_seconds_total) by (cpu))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total memory",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 88
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemTotal_bytes"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value"
       }
     }
   ]

--- a/infra/grafana/install.sh
+++ b/infra/grafana/install.sh
@@ -2,7 +2,7 @@
 
 # Reproducible monitoring installer for vedicpanchanga.com
 # ---------------------------------------------------------
-# Installs / refreshes the full observability stack and provisions it from the
+# Installs / refreshes the observability stack and provisions it from the
 # version-controlled files in this folder:
 #
 #   prometheus/prometheus.yml               -> /etc/prometheus/prometheus.yml
@@ -11,16 +11,13 @@
 #   provisioning/dashboards/provider.yml    -> /etc/grafana/provisioning/dashboards/
 #   dashboards/*.json                       -> /var/lib/grafana/dashboards/
 #
-# Stack: Prometheus + Node Exporter + Blackbox Exporter + Grafana.
-# Everything binds to 127.0.0.1. Grafana is reached over the public internet
-# only through the Nginx reverse proxy at https://vedicpanchanga.com/health/
-# (configured by infra/setup-vps.sh). Prometheus (9090), Node Exporter (9100)
-# and Blackbox (9115) are localhost-only - tunnel over SSH to inspect them.
+# Stack: Prometheus + Node Exporter + Blackbox Exporter + Grafana, all bound to
+# 127.0.0.1. Grafana is reachable only through the Nginx /grafana/ proxy (set up
+# by infra/setup-vps.sh); the exporters are localhost-only (SSH-tunnel to view).
 #
-# IDEMPOTENT: safe to re-run. Binaries are only re-downloaded when missing or a
-# version changes; config files are always re-synced from this folder; the
-# Grafana admin password is never touched (server settings come from a systemd
-# drop-in, not a grafana.ini rewrite).
+# IDEMPOTENT: safe to re-run. Binaries are re-downloaded only when missing or a
+# pinned version changes; configs/dashboards are always re-synced; Grafana's
+# [server] keys are patched in place in grafana.ini (admin password preserved).
 #
 # Usage:  sudo bash infra/grafana/install.sh
 
@@ -29,142 +26,98 @@ set -euo pipefail
 PROM_VERSION="2.53.0"
 NODE_EXP_VERSION="1.8.1"
 BLACKBOX_VERSION="0.25.0"
-
-GRAFANA_ROOT_URL="https://vedicpanchanga.com/health/"
+GRAFANA_ROOT_URL="https://vedicpanchanga.com/grafana/"
 GRAFANA_PORT="3002"
+ARCH="linux-amd64"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "========================================="
-echo "  Monitoring Stack (reproducible)"
-echo "========================================="
-echo
-
-if [ "$(id -u)" -ne 0 ]; then
-    echo "Please run as root (use sudo)" >&2
-    exit 1
-fi
+[ "$(id -u)" -eq 0 ] || { echo "Please run as root (use sudo)" >&2; exit 1; }
 
 # ── helpers ───────────────────────────────────────────────────────────────────
-# install_tarball_binary <name> <version> <url> <relative-path-to-binary-in-tar> <dest>
-# Downloads + installs only when the binary is missing or the version differs.
-have_version() { command -v "$1" >/dev/null 2>&1 && "$1" --version 2>&1 | grep -q "$2"; }
+
+# need <binary> <version>: true when the binary is absent or not that version.
+need() {
+    [ -x "$1" ] || return 0
+    case "$("$1" --version 2>&1)" in *"$2"*) return 1 ;; *) return 0 ;; esac
+}
+
+# write_unit <name> <description> <user> <ExecStart>: emit a systemd service.
+write_unit() {
+    cat > "/etc/systemd/system/$1.service" <<EOF
+[Unit]
+Description=$2
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=$3
+Group=$3
+Type=simple
+Restart=always
+RestartSec=5
+ExecStart=$4
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+# install_exporter <project> <version> <user>: download+install a single-binary
+# prometheus exporter from GitHub into /usr/local/bin (project == binary name).
+install_exporter() {
+    local proj=$1 ver=$2 user=$3 tgz="$1-$2.${ARCH}"
+    useradd --no-create-home --shell /bin/false "$user" 2>/dev/null || true
+    if need "/usr/local/bin/$proj" "$ver"; then
+        cd /tmp
+        wget -q "https://github.com/prometheus/${proj}/releases/download/v${ver}/${tgz}.tar.gz"
+        tar xzf "${tgz}.tar.gz"
+        install -m 0755 "${tgz}/${proj}" "/usr/local/bin/${proj}"
+        rm -rf "${tgz}" "${tgz}.tar.gz"
+        echo "   installed /usr/local/bin/${proj}"
+    else
+        echo "   already current"
+    fi
+}
 
 # ── Prometheus ──────────────────────────────────────────────────────────────
 echo "1. Prometheus ${PROM_VERSION}..."
-if [ ! -x /opt/prometheus/prometheus ] || ! /opt/prometheus/prometheus --version 2>&1 | grep -q "$PROM_VERSION"; then
+useradd --no-create-home --shell /bin/false prometheus 2>/dev/null || true
+if need /opt/prometheus/prometheus "$PROM_VERSION"; then
     cd /tmp
-    wget -q "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz"
-    tar xzf "prometheus-${PROM_VERSION}.linux-amd64.tar.gz"
-    rm -rf /opt/prometheus
-    mv "prometheus-${PROM_VERSION}.linux-amd64" /opt/prometheus
-    rm -f "prometheus-${PROM_VERSION}.linux-amd64.tar.gz"
+    tgz="prometheus-${PROM_VERSION}.${ARCH}"
+    wget -q "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/${tgz}.tar.gz"
+    tar xzf "${tgz}.tar.gz"
+    rm -rf /opt/prometheus && mv "${tgz}" /opt/prometheus && rm -f "${tgz}.tar.gz"
     echo "   installed /opt/prometheus"
 else
     echo "   already current"
 fi
-useradd --no-create-home --shell /bin/false prometheus 2>/dev/null || true
 mkdir -p /var/lib/prometheus /etc/prometheus
 install -m 0644 "$SCRIPT_DIR/prometheus/prometheus.yml" /etc/prometheus/prometheus.yml
 chown -R prometheus:prometheus /opt/prometheus /var/lib/prometheus /etc/prometheus
+write_unit prometheus "Prometheus" prometheus \
+    "/opt/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/ --web.console.templates=/opt/prometheus/consoles --web.console.libraries=/opt/prometheus/console_libraries --web.listen-address=127.0.0.1:9090 --web.enable-lifecycle"
 
-cat > /etc/systemd/system/prometheus.service <<'EOF'
-[Unit]
-Description=Prometheus
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-User=prometheus
-Group=prometheus
-Type=simple
-Restart=always
-RestartSec=5
-ExecStart=/opt/prometheus/prometheus \
-  --config.file=/etc/prometheus/prometheus.yml \
-  --storage.tsdb.path=/var/lib/prometheus/ \
-  --web.console.templates=/opt/prometheus/consoles \
-  --web.console.libraries=/opt/prometheus/console_libraries \
-  --web.listen-address=127.0.0.1:9090 \
-  --web.enable-lifecycle
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-# ── Node Exporter ───────────────────────────────────────────────────────────
+# ── Node Exporter ─────────────────────────────────────────────────────────────
 echo "2. Node Exporter ${NODE_EXP_VERSION}..."
-if [ ! -x /usr/local/bin/node_exporter ] || ! /usr/local/bin/node_exporter --version 2>&1 | grep -q "$NODE_EXP_VERSION"; then
-    cd /tmp
-    wget -q "https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXP_VERSION}/node_exporter-${NODE_EXP_VERSION}.linux-amd64.tar.gz"
-    tar xzf "node_exporter-${NODE_EXP_VERSION}.linux-amd64.tar.gz"
-    install -m 0755 "node_exporter-${NODE_EXP_VERSION}.linux-amd64/node_exporter" /usr/local/bin/node_exporter
-    rm -rf "node_exporter-${NODE_EXP_VERSION}.linux-amd64" "node_exporter-${NODE_EXP_VERSION}.linux-amd64.tar.gz"
-    echo "   installed /usr/local/bin/node_exporter"
-else
-    echo "   already current"
-fi
-useradd --no-create-home --shell /bin/false node_exporter 2>/dev/null || true
-
-cat > /etc/systemd/system/node_exporter.service <<'EOF'
-[Unit]
-Description=Node Exporter
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-User=node_exporter
-Group=node_exporter
-Type=simple
-Restart=always
-RestartSec=5
-ExecStart=/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100
-
-[Install]
-WantedBy=multi-user.target
-EOF
+install_exporter node_exporter "$NODE_EXP_VERSION" node_exporter
+write_unit node_exporter "Node Exporter" node_exporter \
+    "/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100"
 
 # ── Blackbox Exporter ─────────────────────────────────────────────────────────
 echo "3. Blackbox Exporter ${BLACKBOX_VERSION}..."
-if [ ! -x /usr/local/bin/blackbox_exporter ] || ! /usr/local/bin/blackbox_exporter --version 2>&1 | grep -q "$BLACKBOX_VERSION"; then
-    cd /tmp
-    wget -q "https://github.com/prometheus/blackbox_exporter/releases/download/v${BLACKBOX_VERSION}/blackbox_exporter-${BLACKBOX_VERSION}.linux-amd64.tar.gz"
-    tar xzf "blackbox_exporter-${BLACKBOX_VERSION}.linux-amd64.tar.gz"
-    install -m 0755 "blackbox_exporter-${BLACKBOX_VERSION}.linux-amd64/blackbox_exporter" /usr/local/bin/blackbox_exporter
-    rm -rf "blackbox_exporter-${BLACKBOX_VERSION}.linux-amd64" "blackbox_exporter-${BLACKBOX_VERSION}.linux-amd64.tar.gz"
-    echo "   installed /usr/local/bin/blackbox_exporter"
-else
-    echo "   already current"
-fi
-useradd --no-create-home --shell /bin/false blackbox 2>/dev/null || true
+install_exporter blackbox_exporter "$BLACKBOX_VERSION" blackbox
 mkdir -p /etc/blackbox_exporter
 install -m 0644 "$SCRIPT_DIR/blackbox/blackbox.yml" /etc/blackbox_exporter/blackbox.yml
 chown -R blackbox:blackbox /etc/blackbox_exporter
-
-cat > /etc/systemd/system/blackbox_exporter.service <<'EOF'
-[Unit]
-Description=Blackbox Exporter
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-User=blackbox
-Group=blackbox
-Type=simple
-Restart=always
-RestartSec=5
-ExecStart=/usr/local/bin/blackbox_exporter \
-  --config.file=/etc/blackbox_exporter/blackbox.yml \
-  --web.listen-address=127.0.0.1:9115
-
-[Install]
-WantedBy=multi-user.target
-EOF
+write_unit blackbox_exporter "Blackbox Exporter" blackbox \
+    "/usr/local/bin/blackbox_exporter --config.file=/etc/blackbox_exporter/blackbox.yml --web.listen-address=127.0.0.1:9115"
 
 # ── Grafana ─────────────────────────────────────────────────────────────────
 echo "4. Grafana..."
 if ! command -v grafana-server >/dev/null 2>&1 && [ ! -x /usr/sbin/grafana-server ]; then
-    apt-get install -y apt-transport-https software-properties-common gnupg >/dev/null
+    apt-get install -y apt-transport-https gnupg >/dev/null
     mkdir -p /etc/apt/keyrings
     wget -qO- https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
     echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
@@ -176,34 +129,46 @@ else
     echo "   already installed"
 fi
 
-# Provisioning (datasource + dashboard provider) - always re-synced from repo.
+# Provisioning + dashboards, always re-synced from this folder.
 mkdir -p /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards
-install -m 0644 "$SCRIPT_DIR/provisioning/datasources/prometheus.yml" \
-    /etc/grafana/provisioning/datasources/prometheus.yml
-install -m 0644 "$SCRIPT_DIR/provisioning/dashboards/provider.yml" \
-    /etc/grafana/provisioning/dashboards/provider.yml
-# Drop any legacy provisioning files so we don't end up with duplicate file
-# providers / duplicate datasource UIDs pointing at the same resources.
-rm -f /etc/grafana/provisioning/dashboards/dashboard-provider.yml
-rm -f /etc/grafana/provisioning/datasources/prometheus-datasource.yml
-
-# Dashboards - copy every JSON from the repo (adds/updates apps-mon, leaves
-# any other dashboards already in /var/lib/grafana/dashboards untouched).
+install -m 0644 "$SCRIPT_DIR/provisioning/datasources/prometheus.yml" /etc/grafana/provisioning/datasources/prometheus.yml
+install -m 0644 "$SCRIPT_DIR/provisioning/dashboards/provider.yml"     /etc/grafana/provisioning/dashboards/provider.yml
+# Drop legacy provisioning files (avoid duplicate providers / datasource UIDs).
+rm -f /etc/grafana/provisioning/dashboards/dashboard-provider.yml \
+      /etc/grafana/provisioning/datasources/prometheus-datasource.yml
 install -m 0644 "$SCRIPT_DIR"/dashboards/*.json /var/lib/grafana/dashboards/
 chown -R grafana:grafana /etc/grafana/provisioning /var/lib/grafana/dashboards
 
-# Server settings via a systemd drop-in (env overrides win over grafana.ini and
-# leave the admin password alone). Forces 127.0.0.1 bind + the /health subpath.
-mkdir -p /etc/systemd/system/grafana-server.service.d
-cat > /etc/systemd/system/grafana-server.service.d/override.conf <<EOF
-[Service]
-Environment=GF_SERVER_HTTP_ADDR=127.0.0.1
-Environment=GF_SERVER_HTTP_PORT=${GRAFANA_PORT}
-Environment=GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL}
-Environment=GF_SERVER_SERVE_FROM_SUB_PATH=true
-Environment=GF_USERS_ALLOW_SIGN_UP=false
-Environment=GF_AUTH_ANONYMOUS_ENABLED=false
-EOF
+# Patch grafana.ini [server] in place for the /grafana/ subpath + localhost bind.
+# Only these keys are touched; the admin password and everything else are kept.
+# grafana.ini is read by both the apt package and a manual /opt install.
+GRAFANA_ROOT_URL="$GRAFANA_ROOT_URL" GRAFANA_PORT="$GRAFANA_PORT" \
+python3 - /etc/grafana/grafana.ini <<'PYEOF'
+import os, re, sys
+path = sys.argv[1]
+want = {
+    "http_addr": "127.0.0.1",
+    "http_port": os.environ["GRAFANA_PORT"],
+    "root_url": os.environ["GRAFANA_ROOT_URL"],
+    "serve_from_sub_path": "true",
+}
+lines = open(path).readlines() if os.path.exists(path) else []
+start = next((i for i, ln in enumerate(lines) if ln.strip().lower() == "[server]"), None)
+if start is None:
+    lines += ["\n[server]\n"] + [f"{k} = {v}\n" for k, v in want.items()]
+else:
+    end = next((j for j in range(start + 1, len(lines)) if re.match(r"\s*\[", lines[j])), len(lines))
+    seen = set()
+    for j in range(start + 1, end):
+        m = re.match(r"\s*;?\s*([A-Za-z0-9_]+)\s*=", lines[j])
+        if m and m.group(1) in want and m.group(1) not in seen:
+            lines[j] = f"{m.group(1)} = {want[m.group(1)]}\n"
+            seen.add(m.group(1))
+    lines[start + 1:start + 1] = [f"{k} = {want[k]}\n" for k in want if k not in seen]
+open(path, "w").writelines(lines)
+print("  grafana.ini [server] set:", ", ".join(want))
+PYEOF
+chown root:grafana /etc/grafana/grafana.ini 2>/dev/null || true
 
 # ── Start / restart ───────────────────────────────────────────────────────────
 echo
@@ -211,22 +176,15 @@ echo "5. (Re)starting services..."
 systemctl daemon-reload
 systemctl enable prometheus node_exporter blackbox_exporter grafana-server >/dev/null 2>&1 || true
 systemctl restart prometheus node_exporter blackbox_exporter grafana-server
-
 sleep 4
 
 echo
-echo "========================================="
-echo "  Done. All exporters bound to 127.0.0.1."
-echo "========================================="
+echo "  Done. Exporters bound to 127.0.0.1; Grafana via the Nginx /grafana/ proxy."
 for svc in prometheus node_exporter blackbox_exporter grafana-server; do
     printf '  %-20s %s\n' "$svc" "$(systemctl is-active "$svc")"
 done
 echo
-echo "Grafana (via Nginx):  ${GRAFANA_ROOT_URL%/}"
-echo "Dashboard:            ${GRAFANA_ROOT_URL%/}/d/apps-mon/application-monitoring"
-echo
-echo "Local-only (SSH tunnel to inspect):"
-echo "  Prometheus  127.0.0.1:9090   Node 127.0.0.1:9100   Blackbox 127.0.0.1:9115"
-echo
-echo "NOTE: ensure infra/setup-vps.sh has been run so Nginx proxies /health/ -> Grafana,"
-echo "      and that UFW does NOT expose 3002/9090/9100/9115 publicly."
+echo "  Grafana:    ${GRAFANA_ROOT_URL%/}"
+echo "  Dashboard:  ${GRAFANA_ROOT_URL%/}/d/apps-mon/application-monitoring"
+echo "  NOTE: run infra/setup-vps.sh so Nginx proxies /grafana/ and UFW keeps"
+echo "        3002/9090/9100/9115 off the public internet."

--- a/infra/grafana/prometheus/prometheus.yml
+++ b/infra/grafana/prometheus/prometheus.yml
@@ -13,6 +13,13 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9100']
 
+  # Application metrics from the FastAPI backend (request rate, latency, errors).
+  # /metrics is not proxied by Nginx, so it is scraped directly and stays private.
+  - job_name: 'panchanga-backend'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['127.0.0.1:8001']
+
   # Blackbox HTTP probes - application uptime, latency, TLS expiry.
   # Targets are probed *through* the blackbox exporter on 127.0.0.1:9115.
   #   - the public URL exercises the full chain (Cloudflare -> Nginx -> backend)

--- a/infra/setup-vps.sh
+++ b/infra/setup-vps.sh
@@ -264,8 +264,20 @@ server {
         add_header X-Markdown-Tokens "430" always;
     }
 
-    location /health/ {
-        proxy_pass http://127.0.0.1:3002/;
+    # App health endpoint - proxied to the FastAPI backend's /api/health.
+    location = /health {
+        proxy_pass http://127.0.0.1:8001/api/health;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # Grafana monitoring UI under /grafana/ (binds 127.0.0.1:3002 with
+    # root_url=.../grafana/ + serve_from_sub_path). Pass the prefix through
+    # intact: no trailing slash on proxy_pass, no proxy_redirect.
+    location /grafana/ {
+        proxy_pass http://127.0.0.1:3002;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
@@ -273,7 +285,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_redirect / /health/;
     }
 
     location /api/ {
@@ -379,12 +390,22 @@ server {
         add_header X-Markdown-Tokens "430" always;
     }
 
-    # Grafana monitoring UI, reverse-proxied under /health/. Grafana binds to
-    # 127.0.0.1:3002 (see infra/grafana/install.sh), configured with
-    # root_url=.../health/ + serve_from_sub_path so it serves correctly here.
-    # The app's own health JSON is at /api/health (proxied to the backend below).
-    location /health/ {
-        proxy_pass http://127.0.0.1:3002/;
+    # App health endpoint - proxied to the FastAPI backend's /api/health.
+    location = /health {
+        proxy_pass http://127.0.0.1:8001/api/health;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # Grafana monitoring UI, reverse-proxied under /grafana/. Grafana binds to
+    # 127.0.0.1:3002 (see infra/grafana/install.sh) with root_url=.../grafana/ +
+    # serve_from_sub_path, so the /grafana/ prefix must be passed through intact
+    # (no trailing slash on proxy_pass, no proxy_redirect). The app's own health
+    # JSON is at /api/health (also exposed at /health above).
+    location /grafana/ {
+        proxy_pass http://127.0.0.1:3002;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
@@ -392,7 +413,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_redirect / /health/;
     }
 
     location /api/ {
@@ -433,7 +453,7 @@ ufw allow 22/tcp  comment 'SSH'   >/dev/null
 ufw allow 80/tcp  comment 'HTTP'  >/dev/null
 ufw allow 443/tcp comment 'HTTPS' >/dev/null
 # Monitoring (see AGENTS.md §8). Exporters bind to 127.0.0.1 and Grafana is
-# reached via the /health/ Nginx proxy above, so NONE of these ports are exposed
+# reached via the /grafana/ Nginx proxy above, so NONE of these ports are exposed
 # publicly. Drop any legacy public allows left by earlier setups.
 for mon_port in 3002 9090 9100 9115; do
     ufw delete allow "$mon_port"/tcp >/dev/null 2>&1 || true
@@ -466,7 +486,7 @@ if [ "$TLS_ENABLED" = "1" ]; then
 echo "Next steps:"
 echo "  1. Cloudflare → SSL/TLS → Overview → set mode to 'Full (strict)'"
 echo "  2. Install monitoring (optional):  sudo bash $APP_DIR/infra/grafana/install.sh"
-echo "     Grafana is then served at https://vedicpanchanga.com/health/ (ports stay localhost-only)"
+echo "     Grafana is then served at https://vedicpanchanga.com/grafana/ (ports stay localhost-only)"
 else
 echo "Next steps:"
 echo "  1. Cloudflare DNS: A record vedicpanchanga.com → this server IP (proxied)"
@@ -482,8 +502,8 @@ echo "  6. (Meanwhile) Cloudflare SSL/TLS mode 'Flexible' brings the site up imm
 fi
 echo
 if systemctl is-active --quiet grafana-server 2>/dev/null; then
-    echo "Grafana:  https://vedicpanchanga.com/health/  (proxied; binds 127.0.0.1:3002)"
-    echo "  App Monitoring dashboard:  https://vedicpanchanga.com/health/d/apps-mon/application-monitoring"
+    echo "Grafana:  https://vedicpanchanga.com/grafana/  (proxied; binds 127.0.0.1:3002)"
+    echo "  App Monitoring dashboard:  https://vedicpanchanga.com/grafana/d/apps-mon/application-monitoring"
     echo
 fi
 echo "Useful commands:"


### PR DESCRIPTION
Version-controlled monitoring stack under infra/grafana/, Grafana served behind Nginx at /grafana/, app health at /health, FastAPI instrumented for Prometheus, and a full application-level Grafana dashboard.

- backend: GET /api/health readiness probe (200 ok / 503 degraded). FastAPI instrumented with prometheus-fastapi-instrumentator, metrics at /metrics (not proxied by Nginx -> Prometheus scrapes 127.0.0.1:8001 directly, stays private). Nginx also exposes the health JSON at /health.
- infra/grafana/: idempotent install.sh (Prometheus + Node + Blackbox + Grafana), all bound to 127.0.0.1, provisioned from version-controlled config; Grafana [server] subpath/bind set idempotently in grafana.ini (admin password kept). prometheus.yml scrapes node, the backend /metrics, and blackbox probes of /api/health (end-to-end), the homepage, and the origin backend.
- dashboards/application-monitoring.json (uid apps-mon): 41-panel dashboard in 7 rows - service health, application performance (request rate, 5xx error rate, latency p50/p90/p95/p99, by-endpoint rate + latency), availability & latency, HTTP & TLS detail, host utilisation, host resources over time, host info.
- setup-vps.sh: location = /health -> backend /api/health; Grafana proxied under /grafana/ (prefix passed through intact); monitoring ports 3002/9090/9100/9115 kept off the public firewall (localhost-only).
- remove the outdated one-shot setup-monitoring.sh; docs updated.