### PR TITLE
infra: full monitoring stack - 3 new dashboards, all exporters, repli…

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -1,11 +1,11 @@
 # infra/grafana/
 
-Version-controlled, reproducible monitoring stack for
-<https://vedicpanchanga.com>. Everything here is the source of truth: the
+Version-controlled, reproducible monitoring stack for this VPS (vedicpanchanga.com
+plus the other sites it hosts). Everything here is the source of truth: the
 installer copies these files into place, so the live config can always be
-rebuilt from git.
+rebuilt from git - or replicated onto a brand-new server.
 
-## Install / refresh
+## Install / refresh (this server)
 
 ```bash
 sudo bash infra/grafana/install.sh
@@ -13,76 +13,118 @@ sudo bash infra/grafana/install.sh
 
 Idempotent - safe to re-run. Binaries are re-downloaded only when missing or a
 pinned version changes; config files and dashboards are always re-synced from
-this folder; the Grafana admin password is never touched.
+this folder; the Grafana admin password is never touched. An existing Grafana
+(apt package or manual /opt build) is detected and reused, never duplicated.
+
+## Replicating on a new server
+
+1. Clone the repo, then edit for the new host:
+   - `prometheus/prometheus.yml` - replace the blackbox `static_configs`
+     targets with the sites that run there (keep the `app` / `scope: public|origin`
+     label scheme - the web-traffic dashboard groups by it), and drop scrape
+     jobs for exporters you will not run (e.g. `cadvisor` if there is no Docker,
+     `panchanga-backend` if the FastAPI app is not deployed).
+   - `process-exporter/process-exporter.yml` - list that server's app processes.
+     Keep `groupname`s stable; the apps-containers dashboard filters on them.
+   - `install.sh` - set `GRAFANA_ROOT_URL` to the new domain.
+2. `sudo bash infra/grafana/install.sh`
+3. Point Nginx at Grafana (see `infra/setup-vps.sh` for the exact block):
+   `location /grafana/ { proxy_pass http://127.0.0.1:3002; }` - no trailing
+   slash on the proxy_pass, no proxy_redirect; a trailing slash strips the
+   prefix and Grafana's assets 404 ("failed to load application files").
+4. Set the admin password (the value in grafana.ini only applies on first boot):
+   `sudo -u grafana /opt/grafana/bin/grafana cli --homepath /opt/grafana --config /etc/grafana/grafana.ini admin reset-admin-password <new>`
+   (apt installs: `grafana-cli admin reset-admin-password <new>`).
+5. Firewall: keep only 22/80/443 open (UFW default deny incoming). Every
+   component below binds to 127.0.0.1, so nothing else is exposed. Remember
+   UFW cannot block Docker-published ports - containers must publish on
+   `127.0.0.1:...`, which `install.sh` does for cadvisor.
 
 ## What runs (all bound to 127.0.0.1)
 
-| Component         | Port | Reachable from outside? |
-|-------------------|------|-------------------------|
-| Grafana           | 3002 | Yes, via Nginx `/grafana/` proxy only |
-| Prometheus        | 9090 | No (SSH tunnel)         |
-| Node Exporter     | 9100 | No (SSH tunnel)         |
-| Blackbox Exporter | 9115 | No (SSH tunnel)         |
+| Component               | Port | Purpose                                   | Reachable from outside? |
+|-------------------------|------|-------------------------------------------|-------------------------|
+| Grafana                 | 3002 | dashboards                                | via Nginx `/grafana/` only |
+| Prometheus              | 9090 | metrics store, 15s scrape, hot-reloadable | no (SSH tunnel)         |
+| node_exporter           | 9100 | host CPU/mem/disk/net/PSI                 | no                      |
+| blackbox_exporter       | 9115 | HTTP probes of every site (public+origin) | no                      |
+| nginx-prometheus-exporter | 9113 | nginx requests + connection states (stub_status on 8081) | no |
+| process-exporter        | 9256 | per-application CPU/mem/threads/fds       | no                      |
+| cadvisor (Docker)       | 8080 | Docker containers + systemd service cgroups | no                    |
 
-Grafana `[server]` settings (`root_url=https://vedicpanchanga.com/grafana/`,
-`serve_from_sub_path = true`, `http_addr = 127.0.0.1`) are set idempotently in
-`grafana.ini` by `install.sh` - only those keys are touched, so the admin
-password and everything else are preserved. The matching Nginx rule passes the
-`/grafana/` prefix through unchanged (`proxy_pass http://127.0.0.1:3002;`, no
-trailing slash, no `proxy_redirect`); a trailing slash would strip the prefix
-and Grafana's assets would 404 ("failed to load application files").
+cadvisor is pinned to `v0.52.1`: older images (the previous `:latest`, v0.49.1)
+ship a Docker client the current daemon rejects (API 1.41 < min 1.44), and
+container `name` labels silently disappear.
+
+Config changes: `prometheus.yml` can be hot-reloaded with
+`curl -X POST http://127.0.0.1:9090/-/reload` after copying it to
+`/etc/prometheus/`; dashboards re-provision within 30s of landing in
+`/var/lib/grafana/dashboards/`; everything else needs a service restart
+(`install.sh` does all of this for you).
 
 ## Layout
 
 ```
 grafana/
-|-- install.sh                              idempotent installer + provisioner
-|-- prometheus/prometheus.yml               scrape config (self, node, blackbox jobs)
-|-- blackbox/blackbox.yml                   http_2xx prober module
+|-- install.sh                                idempotent installer + provisioner
+|-- prometheus/prometheus.yml                 scrape config (node, backend, blackbox,
+|                                             nginx, process-exporter, cadvisor)
+|-- blackbox/blackbox.yml                     http_2xx prober module
+|-- process-exporter/process-exporter.yml     per-app process groups
+|-- nginx/stub_status.conf                    localhost stub_status for the exporter
 |-- provisioning/
-|   |-- datasources/prometheus.yml          Prometheus datasource (uid: prometheus)
-|   +-- dashboards/provider.yml             file provider -> /var/lib/grafana/dashboards
+|   |-- datasources/prometheus.yml            Prometheus datasource (uid: prometheus)
+|   +-- dashboards/provider.yml               file provider -> /var/lib/grafana/dashboards
 +-- dashboards/
-    +-- application-monitoring.json         uid apps-mon (the dashboard below)
+    |-- generate.py                           regenerates the three dashboards below
+    |-- server-overview.json                  uid server-overview
+    |-- web-traffic.json                      uid web-traffic
+    |-- apps-containers.json                  uid apps-containers
+    +-- application-monitoring.json           uid apps-mon (legacy, vedicpanchanga app)
 ```
 
-## Application Monitoring dashboard
+## Dashboards
 
-UID `apps-mon`, served at:
+All served under `${GRAFANA_ROOT_URL}d/<uid>`:
 
-```
-https://vedicpanchanga.com/grafana/d/apps-mon/application-monitoring
-```
+- **server-overview** - Server Overview - Host and System. At-a-glance stats
+  (uptime, CPU, load, memory, disk, TCP), CPU by mode, load vs cores, PSI
+  pressure stall, memory breakdown, swap/fds, filesystem usage, disk
+  IOPS/throughput/busy, network traffic and errors.
+- **web-traffic** - Web Traffic and Uptime - All Sites. Per-site UP/DOWN and
+  TLS expiry stats, nginx requests/s and connection states, per-site probe
+  latency split public chain (Cloudflare -> Nginx -> app) vs origin
+  (127.0.0.1) so network and app slowness are distinguishable, HTTP phase
+  breakdown (DNS/connect/TLS/processing/transfer), status codes, 1h rolling
+  availability, and the panchanga FastAPI process (CPU, RSS, fds, GC).
+- **apps-containers** - Applications and Containers - Per App. process-exporter
+  groups (CPU, resident memory, process/thread counts, fds, disk IO per app),
+  Docker containers by name (CPU, working set, network, disk IO via cadvisor),
+  and systemd service cgroups (CPU, memory).
+- **apps-mon** - the original vedicpanchanga application dashboard (service
+  health, availability, host utilisation). Kept as-is.
 
-Detailed, grouped into rows: **Service health** (status, 24h uptime, response
-time, HTTP status, TLS expiry), **Application performance** (request rate, 5xx
-error rate, latency p50/p90/p95/p99, request rate + p95 latency by endpoint),
-**Availability & latency** (per-target timeseries + status table), **HTTP & TLS
-detail** (status code over time, HTTP phase durations, DNS lookup, redirects,
-content length, HTTPS flag), **Host utilisation** (CPU / memory / disk gauges +
-load average), **Host resources over time** (CPU, memory breakdown, network,
-disk I/O, filesystem-by-mount), and **Host info** (uptime, CPU cores, total
-memory).
+## Editing dashboards
 
-The application metrics come from the FastAPI backend, instrumented with
-`prometheus-fastapi-instrumentator` and exposed at `/metrics`. That path is not
-proxied by Nginx, so Prometheus scrapes it directly on `127.0.0.1:8001` and it
-never reaches the public internet.
+Preferred: edit `dashboards/generate.py` (panel definitions are short Python)
+and run `python3 dashboards/generate.py` - it rewrites the three JSON files in
+place. Alternatively edit in the Grafana UI, export the JSON model, and
+overwrite the file, keeping its `"uid"`. Either way commit the JSON; deploy by
+re-running `install.sh` or copying to `/var/lib/grafana/dashboards/` (the file
+provider rescans every 30s).
 
-Blackbox probe targets (defined in `prometheus/prometheus.yml`):
+## Probe targets (prometheus/prometheus.yml)
 
-- `https://vedicpanchanga.com/api/health` - full chain (Cloudflare -> Nginx -> backend)
-- `https://vedicpanchanga.com/` - homepage
-- `http://127.0.0.1:8001/api/health` - backend origin (isolates FastAPI)
+Each site gets a `public` probe (full chain through Cloudflare and Nginx) and
+an `origin` probe (the local app port, isolating the app from the network):
 
-> The backend readiness endpoint is `GET /api/health` (returns 200 + `status:ok`
-> when the Swiss Ephemeris data is present, 503 + `status:degraded` otherwise).
-> The Grafana UI lives under `/grafana/`; the app's health is `/api/health`
-> (also exposed at `/health`).
+| app            | public                              | origin                            |
+|----------------|-------------------------------------|-----------------------------------|
+| vedicpanchanga | https://vedicpanchanga.com/ + /api/health | http://127.0.0.1:8001/api/health |
+| fizgpt         | https://fizgpt.com/                 | http://127.0.0.1:3000/            |
+| exportaichat   | https://exportaichat.com/           | http://127.0.0.1:3003/            |
 
-## Editing the dashboard
-
-Edit it in the Grafana UI, then export the model (Dashboard settings -> JSON
-Model / Export) and overwrite `dashboards/application-monitoring.json`, keeping
-`"uid": "apps-mon"`. Commit the file so the change is reproducible. The file
-provider reloads every 30s.
+> The panchanga backend readiness endpoint is `GET /api/health` (200 +
+> `status:ok` when the Swiss Ephemeris data is present, 503 otherwise). Its
+> `/metrics` endpoint is not proxied by Nginx; Prometheus scrapes it directly
+> on `127.0.0.1:8001`, so it never reaches the public internet.

--- a/infra/grafana/dashboards/apps-containers.json
+++ b/infra/grafana/dashboards/apps-containers.json
@@ -1,0 +1,935 @@
+{
+  "uid": "apps-containers",
+  "title": "Applications and Containers - Per App",
+  "tags": [
+    "infra",
+    "process-exporter",
+    "cadvisor",
+    "docker"
+  ],
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "links": [],
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 47,
+      "type": "row",
+      "title": "Per-application processes (process-exporter)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 48,
+      "type": "timeseries",
+      "title": "CPU by application",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum by (groupname) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\"}[5m]))",
+          "legendFormat": "{{groupname}}"
+        }
+      ]
+    },
+    {
+      "id": 49,
+      "type": "timeseries",
+      "title": "Resident memory by application",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (groupname) (namedprocess_namegroup_memory_bytes{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\", memtype=\"resident\"})",
+          "legendFormat": "{{groupname}}"
+        }
+      ]
+    },
+    {
+      "id": 50,
+      "type": "timeseries",
+      "title": "Process count by application",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "namedprocess_namegroup_num_procs{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\"}",
+          "legendFormat": "{{groupname}}"
+        }
+      ]
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "Threads by application",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "namedprocess_namegroup_num_threads{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\"}",
+          "legendFormat": "{{groupname}}"
+        }
+      ]
+    },
+    {
+      "id": 52,
+      "type": "timeseries",
+      "title": "Open file descriptors by application",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "namedprocess_namegroup_open_filedesc{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\"}",
+          "legendFormat": "{{groupname}}"
+        }
+      ]
+    },
+    {
+      "id": 53,
+      "type": "timeseries",
+      "title": "Disk IO by application",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (groupname) (irate(namedprocess_namegroup_read_bytes_total{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\"}[5m]))",
+          "legendFormat": "{{groupname}} read"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (groupname) (irate(namedprocess_namegroup_write_bytes_total{groupname=~\"anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude\"}[5m]))",
+          "legendFormat": "{{groupname}} write"
+        }
+      ]
+    },
+    {
+      "id": 54,
+      "type": "row",
+      "title": "Docker containers (cadvisor)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "id": 55,
+      "type": "timeseries",
+      "title": "Container CPU",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum by (name) (irate(container_cpu_usage_seconds_total{name=~\".+\"}[5m]))",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "id": 56,
+      "type": "timeseries",
+      "title": "Container memory (working set)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "container_memory_working_set_bytes{name=~\".+\"}",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "id": 57,
+      "type": "timeseries",
+      "title": "Container network",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (name) (irate(container_network_receive_bytes_total{name=~\".+\"}[5m]))",
+          "legendFormat": "{{name}} rx"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (name) (irate(container_network_transmit_bytes_total{name=~\".+\"}[5m]))",
+          "legendFormat": "{{name}} tx"
+        }
+      ]
+    },
+    {
+      "id": 58,
+      "type": "timeseries",
+      "title": "Container disk IO",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (name) (irate(container_fs_writes_bytes_total{name=~\".+\"}[5m]))",
+          "legendFormat": "{{name}} write"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (name) (irate(container_fs_reads_bytes_total{name=~\".+\"}[5m]))",
+          "legendFormat": "{{name}} read"
+        }
+      ]
+    },
+    {
+      "id": 59,
+      "type": "row",
+      "title": "Systemd services (cgroup accounting via cadvisor)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "panels": []
+    },
+    {
+      "id": 60,
+      "type": "timeseries",
+      "title": "Service CPU",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum by (id) (irate(container_cpu_usage_seconds_total{id=~\"/system.slice/(panchanga-backend|nginx|grafana|prometheus|anyrouter|exportaichat|fizgpt|docker|fail2ban)[^/]*\\\\.service\"}[5m]))",
+          "legendFormat": "{{id}}"
+        }
+      ]
+    },
+    {
+      "id": 61,
+      "type": "timeseries",
+      "title": "Service memory (working set)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "container_memory_working_set_bytes{id=~\"/system.slice/(panchanga-backend|nginx|grafana|prometheus|anyrouter|exportaichat|fizgpt|docker|fail2ban)[^/]*\\\\.service\"}",
+          "legendFormat": "{{id}}"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/generate.py
+++ b/infra/grafana/dashboards/generate.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Generate the three provisioned Grafana dashboards for this VPS."""
+import json, os
+
+OUT = os.path.dirname(os.path.abspath(__file__))
+DS = {"type": "prometheus", "uid": "prometheus"}
+_id = [0]
+
+def nid():
+    _id[0] += 1
+    return _id[0]
+
+def ts(title, queries, unit="short", w=12, h=8, stacked=False, percent_max=None,
+       legend_calcs=("mean", "max", "lastNotNull"), fill=12, desc=""):
+    return {
+        "id": nid(), "type": "timeseries", "title": title, "description": desc,
+        "datasource": DS,
+        "gridPos": {"h": h, "w": w, "x": 0, "y": 0},
+        "fieldConfig": {
+            "defaults": {
+                "color": {"mode": "palette-classic"},
+                "unit": unit, "min": 0,
+                **({"max": percent_max} if percent_max else {}),
+                "custom": {
+                    "drawStyle": "line", "lineWidth": 1, "fillOpacity": fill,
+                    "showPoints": "never", "spanNulls": True, "pointSize": 5,
+                    "stacking": {"mode": "normal" if stacked else "none", "group": "A"},
+                    "axisPlacement": "auto", "gradientMode": "opacity",
+                    "thresholdsStyle": {"mode": "off"},
+                },
+            },
+            "overrides": [],
+        },
+        "options": {
+            "legend": {"displayMode": "table", "placement": "bottom",
+                       "showLegend": True, "calcs": list(legend_calcs)},
+            "tooltip": {"mode": "multi", "sort": "desc"},
+        },
+        "targets": [
+            {"refId": chr(65 + i), "datasource": DS, "expr": e, "legendFormat": l}
+            for i, (e, l) in enumerate(queries)
+        ],
+    }
+
+def stat(title, expr, unit="short", w=4, h=4, thresholds=None, mappings=None,
+         decimals=None, desc=""):
+    th = thresholds or [{"color": "green", "value": None}]
+    return {
+        "id": nid(), "type": "stat", "title": title, "description": desc,
+        "datasource": DS,
+        "gridPos": {"h": h, "w": w, "x": 0, "y": 0},
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                **({"decimals": decimals} if decimals is not None else {}),
+                "thresholds": {"mode": "absolute", "steps": th},
+                "mappings": mappings or [],
+                "color": {"mode": "thresholds"},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "colorMode": "value", "graphMode": "area", "justifyMode": "auto",
+            "orientation": "auto", "textMode": "auto",
+        },
+        "targets": [{"refId": "A", "datasource": DS, "expr": expr, "legendFormat": ""}],
+    }
+
+def row(title):
+    return {"id": nid(), "type": "row", "title": title, "collapsed": False,
+            "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}, "panels": []}
+
+def layout(panels):
+    """Assign gridPos top to bottom; rows reset the cursor."""
+    x = y = 0
+    row_h = 0
+    for p in panels:
+        w, h = p["gridPos"]["w"], p["gridPos"]["h"]
+        if p["type"] == "row":
+            if x:
+                y += row_h
+                x = row_h = 0
+            p["gridPos"].update({"x": 0, "y": y})
+            y += 1
+            continue
+        if x + w > 24:
+            y += row_h
+            x = row_h = 0
+        p["gridPos"].update({"x": x, "y": y})
+        x += w
+        row_h = max(row_h, h)
+    return panels
+
+def dashboard(uid, title, tags, panels, refresh="30s", time_from="now-6h"):
+    return {
+        "uid": uid, "title": title, "tags": tags, "editable": True,
+        "graphTooltip": 1, "schemaVersion": 39, "version": 1,
+        "refresh": refresh, "time": {"from": time_from, "to": "now"},
+        "timezone": "browser", "links": [], "annotations": {"list": []},
+        "templating": {"list": []}, "panels": layout(panels),
+    }
+
+PCT_TH = [{"color": "green", "value": None}, {"color": "yellow", "value": 70},
+          {"color": "red", "value": 90}]
+UPDOWN = [{"type": "value", "options": {
+    "0": {"text": "DOWN", "color": "red", "index": 1},
+    "1": {"text": "UP", "color": "green", "index": 0}}}]
+APPS = "anyrouter|exportaichat|panchanga-backend|nginx|grafana|prometheus|node|node_exporter|next-server.*|claude"
+NETDEV = 'device!~"lo|docker.*|veth.*|br-.*"'
+FS = 'fstype!~"tmpfs|overlay|squashfs"'
+
+# ---------------------------------------------------------------- dashboard 1
+server = dashboard("server-overview", "Server Overview - Host and System",
+    ["infra", "node-exporter", "host"], [
+    row("At a glance"),
+    stat("Uptime", "node_time_seconds - node_boot_time_seconds", unit="s"),
+    stat("CPU Usage", '100 * (1 - avg(irate(node_cpu_seconds_total{mode="idle"}[5m])))',
+         unit="percent", thresholds=PCT_TH, decimals=1),
+    stat("Load (5m)", "node_load5", decimals=2,
+         thresholds=[{"color": "green", "value": None}, {"color": "yellow", "value": 4},
+                     {"color": "red", "value": 6}]),
+    stat("Memory Used", "100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+         unit="percent", thresholds=PCT_TH, decimals=1),
+    stat("Root Disk Used",
+         '100 * (1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"})',
+         unit="percent", thresholds=PCT_TH, decimals=1),
+    stat("TCP Established", "node_netstat_Tcp_CurrEstab",
+         thresholds=[{"color": "green", "value": None}, {"color": "yellow", "value": 500},
+                     {"color": "red", "value": 2000}]),
+    row("CPU"),
+    ts("CPU usage by mode", [
+        ('100 * avg by (mode) (irate(node_cpu_seconds_total{mode!="idle"}[5m]))', "{{mode}}")],
+       unit="percent", stacked=True, percent_max=100),
+    ts("Load average vs cores", [
+        ("node_load1", "load 1m"), ("node_load5", "load 5m"), ("node_load15", "load 15m"),
+        ('count(node_cpu_seconds_total{mode="idle"})', "cores")], fill=0),
+    ts("Pressure stall (PSI) - share of time tasks waited", [
+        ("irate(node_pressure_cpu_waiting_seconds_total[5m])", "cpu some"),
+        ("irate(node_pressure_io_waiting_seconds_total[5m])", "io some"),
+        ("irate(node_pressure_memory_waiting_seconds_total[5m])", "memory some")],
+       unit="percentunit",
+       desc="Sustained values above 0.1 mean real resource starvation."),
+    ts("Context switches and interrupts", [
+        ("irate(node_context_switches_total[5m])", "context switches"),
+        ("irate(node_intr_total[5m])", "interrupts")], unit="ops"),
+    row("Memory"),
+    ts("Memory breakdown", [
+        ("node_memory_MemTotal_bytes - node_memory_MemFree_bytes - node_memory_Buffers_bytes - node_memory_Cached_bytes", "used"),
+        ("node_memory_Cached_bytes", "cached"),
+        ("node_memory_Buffers_bytes", "buffers"),
+        ("node_memory_MemFree_bytes", "free")],
+       unit="bytes", stacked=True),
+    ts("Swap and file descriptors", [
+        ("node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes", "swap used"),
+        ("node_filefd_allocated", "open fds (count)")], fill=0),
+    row("Disk"),
+    ts("Filesystem usage", [
+        (f'100 * (1 - node_filesystem_avail_bytes{{{FS}}} / node_filesystem_size_bytes{{{FS}}})',
+         "{{mountpoint}}")], unit="percent", percent_max=100, fill=0),
+    ts("Disk IOPS", [
+        ('irate(node_disk_reads_completed_total{device=~"sd.*|vd.*|nvme.*"}[5m])', "{{device}} read"),
+        ('irate(node_disk_writes_completed_total{device=~"sd.*|vd.*|nvme.*"}[5m])', "{{device}} write")],
+       unit="iops"),
+    ts("Disk throughput", [
+        ('irate(node_disk_read_bytes_total{device=~"sd.*|vd.*|nvme.*"}[5m])', "{{device}} read"),
+        ('irate(node_disk_written_bytes_total{device=~"sd.*|vd.*|nvme.*"}[5m])', "{{device}} write")],
+       unit="Bps"),
+    ts("Disk busy time", [
+        ('100 * irate(node_disk_io_time_seconds_total{device=~"sd.*|vd.*|nvme.*"}[5m])', "{{device}}")],
+       unit="percent", percent_max=100),
+    row("Network"),
+    ts("Network traffic", [
+        (f"8 * irate(node_network_receive_bytes_total{{{NETDEV}}}[5m])", "{{device}} rx"),
+        (f"8 * irate(node_network_transmit_bytes_total{{{NETDEV}}}[5m])", "{{device}} tx")],
+       unit="bps"),
+    ts("Network errors and drops", [
+        (f"irate(node_network_receive_errs_total{{{NETDEV}}}[5m])", "{{device}} rx errs"),
+        (f"irate(node_network_transmit_errs_total{{{NETDEV}}}[5m])", "{{device}} tx errs"),
+        (f"irate(node_network_receive_drop_total{{{NETDEV}}}[5m])", "{{device}} rx drop"),
+        (f"irate(node_network_transmit_drop_total{{{NETDEV}}}[5m])", "{{device}} tx drop")],
+       unit="ops"),
+])
+
+# ---------------------------------------------------------------- dashboard 2
+web = dashboard("web-traffic", "Web Traffic and Uptime - All Sites",
+    ["infra", "nginx", "blackbox", "uptime"], [
+    row("Site status"),
+    stat("vedicpanchanga.com",
+         'min(probe_success{app="vedicpanchanga",scope="public"})',
+         mappings=UPDOWN,
+         thresholds=[{"color": "red", "value": None}, {"color": "green", "value": 1}]),
+    stat("fizgpt.com", 'min(probe_success{app="fizgpt",scope="public"})',
+         mappings=UPDOWN,
+         thresholds=[{"color": "red", "value": None}, {"color": "green", "value": 1}]),
+    stat("exportaichat.com", 'min(probe_success{app="exportaichat",scope="public"})',
+         mappings=UPDOWN,
+         thresholds=[{"color": "red", "value": None}, {"color": "green", "value": 1}]),
+    stat("Nginx req/s", "irate(nginx_http_requests_total[5m])", unit="reqps", decimals=2),
+    stat("Active connections", "nginx_connections_active"),
+    stat("Nearest TLS expiry",
+         "min((probe_ssl_earliest_cert_expiry - time()) / 86400)", unit="d", decimals=0,
+         thresholds=[{"color": "red", "value": None}, {"color": "yellow", "value": 14},
+                     {"color": "green", "value": 30}]),
+    row("Nginx (all sites combined)"),
+    ts("HTTP requests per second", [
+        ("irate(nginx_http_requests_total[5m])", "requests/s")], unit="reqps"),
+    ts("Connection states", [
+        ("nginx_connections_active", "active"),
+        ("nginx_connections_reading", "reading"),
+        ("nginx_connections_writing", "writing"),
+        ("nginx_connections_waiting", "waiting (keepalive)")], fill=0),
+    ts("Connections accepted vs handled", [
+        ("irate(nginx_connections_accepted[5m])", "accepted/s"),
+        ("irate(nginx_connections_handled[5m])", "handled/s")], unit="ops",
+       desc="accepted > handled means connections are being dropped."),
+    row("Per-site availability and latency (blackbox probes)"),
+    ts("Probe success (1 = up)", [
+        ("probe_success", "{{app}} {{scope}}")], percent_max=1, fill=0, h=7),
+    ts("Probe duration - full chain vs origin", [
+        ("probe_duration_seconds", "{{app}} {{scope}}")], unit="s", h=7),
+    ts("HTTP phase breakdown (public probes)", [
+        ('avg by (app, phase) (probe_http_duration_seconds{scope="public"})', "{{app}} {{phase}}")],
+       unit="s", h=7,
+       desc="resolve / connect / tls / processing / transfer - where slowness lives."),
+    ts("HTTP status codes", [
+        ("probe_http_status_code", "{{app}} {{scope}}")], fill=0, h=7),
+    ts("TLS certificate days remaining", [
+        ('(probe_ssl_earliest_cert_expiry{scope="public"} - time()) / 86400', "{{app}}")],
+       unit="d", fill=0, h=7),
+    ts("Availability (1h rolling)", [
+        ('100 * avg_over_time(probe_success{scope="public"}[1h])', "{{app}}")],
+       unit="percent", percent_max=100, fill=0, h=7),
+    row("Panchanga API backend (FastAPI on :8001)"),
+    ts("Backend CPU", [
+        ('100 * irate(process_cpu_seconds_total{job="panchanga-backend"}[5m])', "cpu")],
+       unit="percent"),
+    ts("Backend memory (RSS)", [
+        ('process_resident_memory_bytes{job="panchanga-backend"}', "resident")], unit="bytes"),
+    ts("Backend open file descriptors", [
+        ('process_open_fds{job="panchanga-backend"}', "open fds")], fill=0),
+    ts("Python garbage collections", [
+        ('irate(python_gc_collections_total{job="panchanga-backend"}[5m])', "gen {{generation}}")],
+       unit="ops"),
+])
+
+# ---------------------------------------------------------------- dashboard 3
+apps = dashboard("apps-containers", "Applications and Containers - Per App",
+    ["infra", "process-exporter", "cadvisor", "docker"], [
+    row("Per-application processes (process-exporter)"),
+    ts("CPU by application", [
+        (f'100 * sum by (groupname) (irate(namedprocess_namegroup_cpu_seconds_total{{groupname=~"{APPS}"}}[5m]))',
+         "{{groupname}}")], unit="percent"),
+    ts("Resident memory by application", [
+        (f'sum by (groupname) (namedprocess_namegroup_memory_bytes{{groupname=~"{APPS}", memtype="resident"}})',
+         "{{groupname}}")], unit="bytes"),
+    ts("Process count by application", [
+        (f'namedprocess_namegroup_num_procs{{groupname=~"{APPS}"}}', "{{groupname}}")], fill=0),
+    ts("Threads by application", [
+        (f'namedprocess_namegroup_num_threads{{groupname=~"{APPS}"}}', "{{groupname}}")], fill=0),
+    ts("Open file descriptors by application", [
+        (f'namedprocess_namegroup_open_filedesc{{groupname=~"{APPS}"}}', "{{groupname}}")], fill=0),
+    ts("Disk IO by application", [
+        (f'sum by (groupname) (irate(namedprocess_namegroup_read_bytes_total{{groupname=~"{APPS}"}}[5m]))',
+         "{{groupname}} read"),
+        (f'sum by (groupname) (irate(namedprocess_namegroup_write_bytes_total{{groupname=~"{APPS}"}}[5m]))',
+         "{{groupname}} write")], unit="Bps"),
+    row("Docker containers (cadvisor)"),
+    ts("Container CPU", [
+        ('100 * sum by (name) (irate(container_cpu_usage_seconds_total{name=~".+"}[5m]))', "{{name}}")],
+       unit="percent"),
+    ts("Container memory (working set)", [
+        ('container_memory_working_set_bytes{name=~".+"}', "{{name}}")], unit="bytes"),
+    ts("Container network", [
+        ('sum by (name) (irate(container_network_receive_bytes_total{name=~".+"}[5m]))', "{{name}} rx"),
+        ('sum by (name) (irate(container_network_transmit_bytes_total{name=~".+"}[5m]))', "{{name}} tx")],
+       unit="Bps"),
+    ts("Container disk IO", [
+        ('sum by (name) (irate(container_fs_writes_bytes_total{name=~".+"}[5m]))', "{{name}} write"),
+        ('sum by (name) (irate(container_fs_reads_bytes_total{name=~".+"}[5m]))', "{{name}} read")],
+       unit="Bps"),
+    row("Systemd services (cgroup accounting via cadvisor)"),
+    ts("Service CPU", [
+        ('100 * sum by (id) (irate(container_cpu_usage_seconds_total{id=~"/system.slice/(panchanga-backend|nginx|grafana|prometheus|anyrouter|exportaichat|fizgpt|docker|fail2ban)[^/]*\\\\.service"}[5m]))',
+         "{{id}}")], unit="percent"),
+    ts("Service memory (working set)", [
+        ('container_memory_working_set_bytes{id=~"/system.slice/(panchanga-backend|nginx|grafana|prometheus|anyrouter|exportaichat|fizgpt|docker|fail2ban)[^/]*\\\\.service"}',
+         "{{id}}")], unit="bytes"),
+])
+
+os.makedirs(OUT, exist_ok=True)
+for d, fname in [(server, "server-overview.json"), (web, "web-traffic.json"),
+                 (apps, "apps-containers.json")]:
+    path = os.path.join(OUT, fname)
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+        f.write("\n")
+    print("wrote", path, len(d["panels"]), "panels")

--- a/infra/grafana/dashboards/server-overview.json
+++ b/infra/grafana/dashboards/server-overview.json
@@ -1,0 +1,1484 @@
+{
+  "uid": "server-overview",
+  "title": "Server Overview - Host and System",
+  "tags": [
+    "infra",
+    "node-exporter",
+    "host"
+  ],
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "links": [],
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "At a glance",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Uptime",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_time_seconds - node_boot_time_seconds",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "CPU Usage",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - avg(irate(node_cpu_seconds_total{mode=\"idle\"}[5m])))",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Load (5m)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 4
+              },
+              {
+                "color": "red",
+                "value": 6
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_load5",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Memory Used",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Root Disk Used",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "TCP Established",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_netstat_Tcp_CurrEstab",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "CPU",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "CPU usage by mode",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * avg by (mode) (irate(node_cpu_seconds_total{mode!=\"idle\"}[5m]))",
+          "legendFormat": "{{mode}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Load average vs cores",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_load1",
+          "legendFormat": "load 1m"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_load5",
+          "legendFormat": "load 5m"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_load15",
+          "legendFormat": "load 15m"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(node_cpu_seconds_total{mode=\"idle\"})",
+          "legendFormat": "cores"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Pressure stall (PSI) - share of time tasks waited",
+      "description": "Sustained values above 0.1 mean real resource starvation.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_pressure_cpu_waiting_seconds_total[5m])",
+          "legendFormat": "cpu some"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_pressure_io_waiting_seconds_total[5m])",
+          "legendFormat": "io some"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_pressure_memory_waiting_seconds_total[5m])",
+          "legendFormat": "memory some"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Context switches and interrupts",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_context_switches_total[5m])",
+          "legendFormat": "context switches"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_intr_total[5m])",
+          "legendFormat": "interrupts"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "row",
+      "title": "Memory",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Memory breakdown",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - node_memory_Buffers_bytes - node_memory_Cached_bytes",
+          "legendFormat": "used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_Cached_bytes",
+          "legendFormat": "cached"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_Buffers_bytes",
+          "legendFormat": "buffers"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_MemFree_bytes",
+          "legendFormat": "free"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Swap and file descriptors",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes",
+          "legendFormat": "swap used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_filefd_allocated",
+          "legendFormat": "open fds (count)"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "row",
+      "title": "Disk",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "panels": []
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Filesystem usage",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs\"})",
+          "legendFormat": "{{mountpoint}}"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Disk IOPS",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "iops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_disk_reads_completed_total{device=~\"sd.*|vd.*|nvme.*\"}[5m])",
+          "legendFormat": "{{device}} read"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_disk_writes_completed_total{device=~\"sd.*|vd.*|nvme.*\"}[5m])",
+          "legendFormat": "{{device}} write"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Disk throughput",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_disk_read_bytes_total{device=~\"sd.*|vd.*|nvme.*\"}[5m])",
+          "legendFormat": "{{device}} read"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_disk_written_bytes_total{device=~\"sd.*|vd.*|nvme.*\"}[5m])",
+          "legendFormat": "{{device}} write"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Disk busy time",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * irate(node_disk_io_time_seconds_total{device=~\"sd.*|vd.*|nvme.*\"}[5m])",
+          "legendFormat": "{{device}}"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "row",
+      "title": "Network",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "panels": []
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Network traffic",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "8 * irate(node_network_receive_bytes_total{device!~\"lo|docker.*|veth.*|br-.*\"}[5m])",
+          "legendFormat": "{{device}} rx"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "8 * irate(node_network_transmit_bytes_total{device!~\"lo|docker.*|veth.*|br-.*\"}[5m])",
+          "legendFormat": "{{device}} tx"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Network errors and drops",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_network_receive_errs_total{device!~\"lo|docker.*|veth.*|br-.*\"}[5m])",
+          "legendFormat": "{{device}} rx errs"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_network_transmit_errs_total{device!~\"lo|docker.*|veth.*|br-.*\"}[5m])",
+          "legendFormat": "{{device}} tx errs"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_network_receive_drop_total{device!~\"lo|docker.*|veth.*|br-.*\"}[5m])",
+          "legendFormat": "{{device}} rx drop"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(node_network_transmit_drop_total{device!~\"lo|docker.*|veth.*|br-.*\"}[5m])",
+          "legendFormat": "{{device}} tx drop"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/web-traffic.json
+++ b/infra/grafana/dashboards/web-traffic.json
@@ -1,0 +1,1459 @@
+{
+  "uid": "web-traffic",
+  "title": "Web Traffic and Uptime - All Sites",
+  "tags": [
+    "infra",
+    "nginx",
+    "blackbox",
+    "uptime"
+  ],
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "links": [],
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 24,
+      "type": "row",
+      "title": "Site status",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "vedicpanchanga.com",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min(probe_success{app=\"vedicpanchanga\",scope=\"public\"})",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "type": "stat",
+      "title": "fizgpt.com",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min(probe_success{app=\"fizgpt\",scope=\"public\"})",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "type": "stat",
+      "title": "exportaichat.com",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min(probe_success{app=\"exportaichat\",scope=\"public\"})",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "type": "stat",
+      "title": "Nginx req/s",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(nginx_http_requests_total[5m])",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "type": "stat",
+      "title": "Active connections",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_connections_active",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "stat",
+      "title": "Nearest TLS expiry",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min((probe_ssl_earliest_cert_expiry - time()) / 86400)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "row",
+      "title": "Nginx (all sites combined)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "HTTP requests per second",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(nginx_http_requests_total[5m])",
+          "legendFormat": "requests/s"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "Connection states",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_connections_active",
+          "legendFormat": "active"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_connections_reading",
+          "legendFormat": "reading"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_connections_writing",
+          "legendFormat": "writing"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_connections_waiting",
+          "legendFormat": "waiting (keepalive)"
+        }
+      ]
+    },
+    {
+      "id": 34,
+      "type": "timeseries",
+      "title": "Connections accepted vs handled",
+      "description": "accepted > handled means connections are being dropped.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(nginx_connections_accepted[5m])",
+          "legendFormat": "accepted/s"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(nginx_connections_handled[5m])",
+          "legendFormat": "handled/s"
+        }
+      ]
+    },
+    {
+      "id": 35,
+      "type": "row",
+      "title": "Per-site availability and latency (blackbox probes)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "id": 36,
+      "type": "timeseries",
+      "title": "Probe success (1 = up)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "probe_success",
+          "legendFormat": "{{app}} {{scope}}"
+        }
+      ]
+    },
+    {
+      "id": 37,
+      "type": "timeseries",
+      "title": "Probe duration - full chain vs origin",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "probe_duration_seconds",
+          "legendFormat": "{{app}} {{scope}}"
+        }
+      ]
+    },
+    {
+      "id": 38,
+      "type": "timeseries",
+      "title": "HTTP phase breakdown (public probes)",
+      "description": "resolve / connect / tls / processing / transfer - where slowness lives.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (app, phase) (probe_http_duration_seconds{scope=\"public\"})",
+          "legendFormat": "{{app}} {{phase}}"
+        }
+      ]
+    },
+    {
+      "id": 39,
+      "type": "timeseries",
+      "title": "HTTP status codes",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "probe_http_status_code",
+          "legendFormat": "{{app}} {{scope}}"
+        }
+      ]
+    },
+    {
+      "id": 40,
+      "type": "timeseries",
+      "title": "TLS certificate days remaining",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "d",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(probe_ssl_earliest_cert_expiry{scope=\"public\"} - time()) / 86400",
+          "legendFormat": "{{app}}"
+        }
+      ]
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Availability (1h rolling)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * avg_over_time(probe_success{scope=\"public\"}[1h])",
+          "legendFormat": "{{app}}"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "type": "row",
+      "title": "Panchanga API backend (FastAPI on :8001)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "panels": []
+    },
+    {
+      "id": 43,
+      "type": "timeseries",
+      "title": "Backend CPU",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * irate(process_cpu_seconds_total{job=\"panchanga-backend\"}[5m])",
+          "legendFormat": "cpu"
+        }
+      ]
+    },
+    {
+      "id": 44,
+      "type": "timeseries",
+      "title": "Backend memory (RSS)",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_resident_memory_bytes{job=\"panchanga-backend\"}",
+          "legendFormat": "resident"
+        }
+      ]
+    },
+    {
+      "id": 45,
+      "type": "timeseries",
+      "title": "Backend open file descriptors",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_open_fds{job=\"panchanga-backend\"}",
+          "legendFormat": "open fds"
+        }
+      ]
+    },
+    {
+      "id": 46,
+      "type": "timeseries",
+      "title": "Python garbage collections",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "opacity",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "irate(python_gc_collections_total{job=\"panchanga-backend\"}[5m])",
+          "legendFormat": "gen {{generation}}"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/install.sh
+++ b/infra/grafana/install.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
 
-# Reproducible monitoring installer for vedicpanchanga.com
-# ---------------------------------------------------------
-# Installs / refreshes the observability stack and provisions it from the
+# Reproducible monitoring installer for vedicpanchanga.com (and clones)
+# ---------------------------------------------------------------------
+# Installs / refreshes the full observability stack and provisions it from the
 # version-controlled files in this folder:
 #
-#   prometheus/prometheus.yml               -> /etc/prometheus/prometheus.yml
-#   blackbox/blackbox.yml                   -> /etc/blackbox_exporter/blackbox.yml
-#   provisioning/datasources/prometheus.yml -> /etc/grafana/provisioning/datasources/
-#   provisioning/dashboards/provider.yml    -> /etc/grafana/provisioning/dashboards/
-#   dashboards/*.json                       -> /var/lib/grafana/dashboards/
+#   prometheus/prometheus.yml                 -> /etc/prometheus/prometheus.yml
+#   blackbox/blackbox.yml                     -> /etc/blackbox_exporter/blackbox.yml
+#   process-exporter/process-exporter.yml     -> /etc/process-exporter/process-exporter.yml
+#   nginx/stub_status.conf                    -> /etc/nginx/conf.d/stub_status.conf
+#   provisioning/datasources/prometheus.yml   -> /etc/grafana/provisioning/datasources/
+#   provisioning/dashboards/provider.yml      -> /etc/grafana/provisioning/dashboards/
+#   dashboards/*.json                         -> /var/lib/grafana/dashboards/
 #
-# Stack: Prometheus + Node Exporter + Blackbox Exporter + Grafana, all bound to
-# 127.0.0.1. Grafana is reachable only through the Nginx /grafana/ proxy (set up
-# by infra/setup-vps.sh); the exporters are localhost-only (SSH-tunnel to view).
+# Stack (everything bound to 127.0.0.1):
+#   Prometheus 9090 | Grafana 3002 (via Nginx /grafana/ proxy)
+#   node_exporter 9100 | blackbox_exporter 9115 | nginx-exporter 9113
+#   process-exporter 9256 | cadvisor 8080 (Docker container, optional)
+#
+# Replicating on a NEW server - edit before running:
+#   - prometheus/prometheus.yml: blackbox targets + app scrape jobs for the
+#     sites that actually run there
+#   - process-exporter/process-exporter.yml: the per-app process groups
+#   - GRAFANA_ROOT_URL below
+#   Then: sudo bash infra/grafana/install.sh
+#   Finally point Nginx at /grafana/ (see infra/setup-vps.sh) and set the
+#   admin password: sudo -u grafana grafana cli admin reset-admin-password ...
 #
 # IDEMPOTENT: safe to re-run. Binaries are re-downloaded only when missing or a
 # pinned version changes; configs/dashboards are always re-synced; Grafana's
@@ -26,6 +38,11 @@ set -euo pipefail
 PROM_VERSION="2.53.0"
 NODE_EXP_VERSION="1.8.1"
 BLACKBOX_VERSION="0.25.0"
+PROC_EXP_VERSION="0.7.10"
+NGINX_EXP_VERSION="1.1.0"
+CADVISOR_TAG="v0.52.1"      # >= v0.52 required: older Docker clients (API 1.41)
+                            # are rejected by current Docker daemons (min 1.44)
+                            # and container name labels silently disappear.
 GRAFANA_ROOT_URL="https://vedicpanchanga.com/grafana/"
 GRAFANA_PORT="3002"
 ARCH="linux-amd64"
@@ -63,14 +80,15 @@ WantedBy=multi-user.target
 EOF
 }
 
-# install_exporter <project> <version> <user>: download+install a single-binary
-# prometheus exporter from GitHub into /usr/local/bin (project == binary name).
+# install_exporter <github-org> <project> <version> <user>: download+install a
+# single-binary exporter packaged as <project>-<version>.<arch>.tar.gz with the
+# binary at <dir>/<project> (the prometheus/ncabatoff release convention).
 install_exporter() {
-    local proj=$1 ver=$2 user=$3 tgz="$1-$2.${ARCH}"
+    local org=$1 proj=$2 ver=$3 user=$4 tgz="$2-$3.${ARCH}"
     useradd --no-create-home --shell /bin/false "$user" 2>/dev/null || true
     if need "/usr/local/bin/$proj" "$ver"; then
         cd /tmp
-        wget -q "https://github.com/prometheus/${proj}/releases/download/v${ver}/${tgz}.tar.gz"
+        wget -q "https://github.com/${org}/${proj}/releases/download/v${ver}/${tgz}.tar.gz"
         tar xzf "${tgz}.tar.gz"
         install -m 0755 "${tgz}/${proj}" "/usr/local/bin/${proj}"
         rm -rf "${tgz}" "${tgz}.tar.gz"
@@ -101,32 +119,90 @@ write_unit prometheus "Prometheus" prometheus \
 
 # ── Node Exporter ─────────────────────────────────────────────────────────────
 echo "2. Node Exporter ${NODE_EXP_VERSION}..."
-install_exporter node_exporter "$NODE_EXP_VERSION" node_exporter
+install_exporter prometheus node_exporter "$NODE_EXP_VERSION" node_exporter
 write_unit node_exporter "Node Exporter" node_exporter \
     "/usr/local/bin/node_exporter --web.listen-address=127.0.0.1:9100"
 
 # ── Blackbox Exporter ─────────────────────────────────────────────────────────
 echo "3. Blackbox Exporter ${BLACKBOX_VERSION}..."
-install_exporter blackbox_exporter "$BLACKBOX_VERSION" blackbox
+install_exporter prometheus blackbox_exporter "$BLACKBOX_VERSION" blackbox
 mkdir -p /etc/blackbox_exporter
 install -m 0644 "$SCRIPT_DIR/blackbox/blackbox.yml" /etc/blackbox_exporter/blackbox.yml
 chown -R blackbox:blackbox /etc/blackbox_exporter
 write_unit blackbox_exporter "Blackbox Exporter" blackbox \
     "/usr/local/bin/blackbox_exporter --config.file=/etc/blackbox_exporter/blackbox.yml --web.listen-address=127.0.0.1:9115"
 
+# ── Process Exporter (per-app CPU/memory/fds) ────────────────────────────────
+echo "4. Process Exporter ${PROC_EXP_VERSION}..."
+install_exporter ncabatoff process-exporter "$PROC_EXP_VERSION" process_exporter
+mkdir -p /etc/process-exporter
+install -m 0644 "$SCRIPT_DIR/process-exporter/process-exporter.yml" /etc/process-exporter/process-exporter.yml
+write_unit process-exporter "Process Exporter" process_exporter \
+    "/usr/local/bin/process-exporter --config.path=/etc/process-exporter/process-exporter.yml --web.listen-address=127.0.0.1:9256"
+
+# ── Nginx Exporter (stub_status) ──────────────────────────────────────────────
+echo "5. Nginx Prometheus Exporter ${NGINX_EXP_VERSION}..."
+useradd --no-create-home --shell /bin/false nginx_exporter 2>/dev/null || true
+if need /usr/local/bin/nginx-prometheus-exporter "$NGINX_EXP_VERSION"; then
+    cd /tmp
+    tgz="nginx-prometheus-exporter_${NGINX_EXP_VERSION}_linux_amd64"
+    wget -q "https://github.com/nginx/nginx-prometheus-exporter/releases/download/v${NGINX_EXP_VERSION}/${tgz}.tar.gz"
+    mkdir -p "$tgz" && tar xzf "${tgz}.tar.gz" -C "$tgz"
+    install -m 0755 "${tgz}/nginx-prometheus-exporter" /usr/local/bin/nginx-prometheus-exporter
+    rm -rf "${tgz}" "${tgz}.tar.gz"
+    echo "   installed /usr/local/bin/nginx-prometheus-exporter"
+else
+    echo "   already current"
+fi
+if [ -d /etc/nginx/conf.d ]; then
+    install -m 0644 "$SCRIPT_DIR/nginx/stub_status.conf" /etc/nginx/conf.d/stub_status.conf
+    nginx -t >/dev/null 2>&1 && systemctl reload nginx && echo "   stub_status on 127.0.0.1:8081"
+else
+    echo "   nginx not present - skipping stub_status.conf"
+fi
+write_unit nginx-exporter "Nginx Prometheus Exporter" nginx_exporter \
+    "/usr/local/bin/nginx-prometheus-exporter --nginx.scrape-uri=http://127.0.0.1:8081/nginx_status --web.listen-address=127.0.0.1:9113"
+
+# ── cAdvisor (Docker containers + systemd service cgroups) ────────────────────
+echo "6. cAdvisor ${CADVISOR_TAG}..."
+if command -v docker >/dev/null 2>&1; then
+    docker rm -f cadvisor >/dev/null 2>&1 || true
+    docker run -d --name cadvisor --restart unless-stopped \
+        -p 127.0.0.1:8080:8080 \
+        -v /:/rootfs:ro \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /sys:/sys:ro \
+        -v /var/lib/docker/:/var/lib/docker:ro \
+        -v /dev/disk/:/dev/disk:ro \
+        --device=/dev/kmsg \
+        "gcr.io/cadvisor/cadvisor:${CADVISOR_TAG}" -logtostderr >/dev/null
+    echo "   cadvisor running on 127.0.0.1:8080"
+else
+    echo "   docker not present - skipped (also remove the cadvisor job from prometheus.yml)"
+fi
+
 # ── Grafana ─────────────────────────────────────────────────────────────────
-echo "4. Grafana..."
-if ! command -v grafana-server >/dev/null 2>&1 && [ ! -x /usr/sbin/grafana-server ]; then
+echo "7. Grafana..."
+# Detect an existing install first: a manual /opt build ships its own
+# 'grafana' unit, the apt package ships 'grafana-server'. Never install a
+# second copy next to a running one. (No `grep -q` on systemctl output: under
+# pipefail the early-exit SIGPIPEs systemctl and the condition silently fails.)
+if [ -x /opt/grafana/bin/grafana ] || systemctl list-unit-files grafana.service 2>/dev/null | grep -E '^grafana\.service' >/dev/null; then
+    GRAFANA_UNIT="grafana"
+    echo "   already installed (manual /opt build, unit: grafana)"
+elif command -v grafana-server >/dev/null 2>&1 || [ -x /usr/sbin/grafana-server ]; then
+    GRAFANA_UNIT="grafana-server"
+    echo "   already installed (apt package)"
+else
     apt-get install -y apt-transport-https gnupg >/dev/null
     mkdir -p /etc/apt/keyrings
-    wget -qO- https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+    wget -qO- https://apt.grafana.com/gpg.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/grafana.gpg
     echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
         > /etc/apt/sources.list.d/grafana.list
     apt-get update >/dev/null
     apt-get install -y grafana
+    GRAFANA_UNIT="grafana-server"
     echo "   installed grafana"
-else
-    echo "   already installed"
 fi
 
 # Provisioning + dashboards, always re-synced from this folder.
@@ -172,19 +248,26 @@ chown root:grafana /etc/grafana/grafana.ini 2>/dev/null || true
 
 # ── Start / restart ───────────────────────────────────────────────────────────
 echo
-echo "5. (Re)starting services..."
+echo "8. (Re)starting services..."
+SERVICES="prometheus node_exporter blackbox_exporter process-exporter nginx-exporter $GRAFANA_UNIT"
 systemctl daemon-reload
-systemctl enable prometheus node_exporter blackbox_exporter grafana-server >/dev/null 2>&1 || true
-systemctl restart prometheus node_exporter blackbox_exporter grafana-server
+# shellcheck disable=SC2086
+systemctl enable $SERVICES >/dev/null 2>&1 || true
+# shellcheck disable=SC2086
+systemctl restart $SERVICES
 sleep 4
 
 echo
-echo "  Done. Exporters bound to 127.0.0.1; Grafana via the Nginx /grafana/ proxy."
-for svc in prometheus node_exporter blackbox_exporter grafana-server; do
+echo "  Done. Everything bound to 127.0.0.1; Grafana via the Nginx /grafana/ proxy."
+for svc in $SERVICES; do
     printf '  %-20s %s\n' "$svc" "$(systemctl is-active "$svc")"
 done
+command -v docker >/dev/null 2>&1 && printf '  %-20s %s\n' "cadvisor (docker)" "$(docker inspect -f '{{.State.Status}}' cadvisor 2>/dev/null || echo absent)"
 echo
-echo "  Grafana:    ${GRAFANA_ROOT_URL%/}"
-echo "  Dashboard:  ${GRAFANA_ROOT_URL%/}/d/apps-mon/application-monitoring"
+echo "  Grafana:     ${GRAFANA_ROOT_URL%/}"
+echo "  Dashboards:  ${GRAFANA_ROOT_URL%/}/d/server-overview   (host and system)"
+echo "               ${GRAFANA_ROOT_URL%/}/d/web-traffic       (all sites, nginx, uptime)"
+echo "               ${GRAFANA_ROOT_URL%/}/d/apps-containers   (per app and container)"
+echo "               ${GRAFANA_ROOT_URL%/}/d/apps-mon          (vedicpanchanga app)"
 echo "  NOTE: run infra/setup-vps.sh so Nginx proxies /grafana/ and UFW keeps"
-echo "        3002/9090/9100/9115 off the public internet."
+echo "        the exporter ports off the public internet."

--- a/infra/grafana/nginx/stub_status.conf
+++ b/infra/grafana/nginx/stub_status.conf
@@ -1,0 +1,14 @@
+# Nginx stub_status endpoint for nginx-prometheus-exporter (port 9113).
+# Deployed by install.sh to /etc/nginx/conf.d/stub_status.conf.
+# Localhost-only: the exporter scrapes http://127.0.0.1:8081/nginx_status.
+server {
+    listen 127.0.0.1:8081;
+    server_name localhost;
+
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+}

--- a/infra/grafana/process-exporter/process-exporter.yml
+++ b/infra/grafana/process-exporter/process-exporter.yml
@@ -1,0 +1,49 @@
+# Per-application process groups for process-exporter (port 9256).
+# Deployed by install.sh to /etc/process-exporter/process-exporter.yml.
+# Each entry becomes a `groupname` label - keep names stable, the
+# apps-containers dashboard filters on them.
+process_names:
+  # Node.js processes (grouped by executable name, e.g. node, next-server).
+  - name: "{{.Comm}}"
+    cmdline:
+    - 'node'
+
+  # Python processes (catch-all; named groups below take precedence).
+  - name: "{{.Matches}}"
+    cmdline:
+    - 'python|python3'
+
+  # VS Code Server
+  - name: "vscode-server"
+    cmdline:
+    - '.vscode-server'
+
+  # Panchanga FastAPI backend (uvicorn server:app on :8001)
+  - name: "panchanga-backend"
+    cmdline:
+    - 'uvicorn.*server:app'
+
+  # ExportAI Chat (Next.js via npm start)
+  - name: "exportaichat"
+    cmdline:
+    - 'npm.*start'
+
+  # Anyrouter API gateway (backs fizgpt.com)
+  - name: "anyrouter"
+    cmdline:
+    - 'anyrouter'
+
+  # Nginx web server
+  - name: "nginx"
+    cmdline:
+    - 'nginx'
+
+  # Claude Code sessions
+  - name: "claude"
+    cmdline:
+    - 'claude'
+
+  # Monitoring stack itself
+  - name: "{{.Comm}}"
+    cmdline:
+    - 'prometheus|grafana|node_exporter'

--- a/infra/grafana/prometheus/prometheus.yml
+++ b/infra/grafana/prometheus/prometheus.yml
@@ -23,7 +23,7 @@ scrape_configs:
   # Blackbox HTTP probes - application uptime, latency, TLS expiry.
   # Targets are probed *through* the blackbox exporter on 127.0.0.1:9115.
   #   - the public URL exercises the full chain (Cloudflare -> Nginx -> backend)
-  #   - the origin URL isolates the FastAPI backend itself
+  #   - the origin URL isolates the app server itself
   - job_name: 'blackbox-http'
     metrics_path: /probe
     params:
@@ -40,6 +40,26 @@ scrape_configs:
         labels:
           app: vedicpanchanga
           scope: origin
+      - targets:
+          - https://fizgpt.com/
+        labels:
+          app: fizgpt
+          scope: public
+      - targets:
+          - http://127.0.0.1:3000/
+        labels:
+          app: fizgpt
+          scope: origin
+      - targets:
+          - https://exportaichat.com/
+        labels:
+          app: exportaichat
+          scope: public
+      - targets:
+          - http://127.0.0.1:3003/
+        labels:
+          app: exportaichat
+          scope: origin
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -47,3 +67,18 @@ scrape_configs:
         target_label: instance
       - target_label: __address__
         replacement: 127.0.0.1:9115
+
+  # Nginx aggregate connection/request metrics (stub_status exporter).
+  - job_name: 'nginx'
+    static_configs:
+      - targets: ['127.0.0.1:9113']
+
+  # Per-process CPU/memory/fd metrics for every app on the box.
+  - job_name: 'process-exporter'
+    static_configs:
+      - targets: ['127.0.0.1:9256']
+
+  # Docker containers + systemd services resource usage (cadvisor).
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['127.0.0.1:8080']


### PR DESCRIPTION
…cable installer

- Add server-overview, web-traffic, apps-containers dashboards (generated by dashboards/generate.py, file-provisioned via /var/lib/grafana/dashboards)
- Scrape nginx (9113), process-exporter (9256), cadvisor (8080) - they were running but never collected
- Blackbox-probe all three sites (vedicpanchanga, fizgpt, exportaichat), public chain and origin separately
- Commit process-exporter groups (fix uvicorn matcher: server:app, not api:app) and nginx stub_status snippet as source of truth
- install.sh: install process/nginx exporters + cadvisor (pinned v0.52.1, older images lose Docker name labels on API < 1.44 daemons), bind all exporters to 127.0.0.1, detect existing /opt grafana without grep -q SIGPIPE bug, batch-safe gpg
- README: replication guide for standing up a new server