### PR TITLE
perf: 2-4x faster PDF rendering

### DIFF
--- a/backend/pdf/core/text.py
+++ b/backend/pdf/core/text.py
@@ -42,43 +42,81 @@ REGULAR = ""  # fpdf2 style codes
 BOLD = "B"
 
 
-def register_fonts(pdf: FPDF) -> None:
-    """Add all script TTF/OTFs and turn on text shaping. Idempotent.
-
-    For CJK we ship Regular only and alias it under both REGULAR and BOLD
-    style keys — bold weight isn't critical for the few CJK headings we
-    draw, and skipping the bold .otf saves ~13 MB of binary on disk.
-    """
-    if "noto-registered" in getattr(pdf, "_panchanga_flags", set()):
-        return
+# Per-family TTF/OTF sources for lazy registration. Parsing a face with
+# fontTools inside add_font is the single most expensive part of a render
+# (~150ms each, >1s for all eight), so faces are only added the first time
+# a text run actually needs their script.
+# For CJK we ship Regular only and alias it under both REGULAR and BOLD
+# style keys - bold weight isn't critical for the few CJK headings we
+# draw, and skipping the bold .otf saves ~13 MB of binary on disk.
+FONT_FILES = {
     # Latin + IAST diacritics + Cyrillic (covers ru without an extra font)
-    pdf.add_font(LATIN_REGULAR, REGULAR, str(FONT_DIR / "NotoSans-Regular.ttf"))
-    pdf.add_font(LATIN_REGULAR, BOLD, str(FONT_DIR / "NotoSans-Bold.ttf"))
+    LATIN_REGULAR: {REGULAR: "NotoSans-Regular.ttf", BOLD: "NotoSans-Bold.ttf"},
     # Devanagari (Hindi, Nepali)
-    pdf.add_font(DEV_REGULAR, REGULAR, str(FONT_DIR / "NotoSansDevanagari-Regular.ttf"))
-    pdf.add_font(DEV_REGULAR, BOLD, str(FONT_DIR / "NotoSansDevanagari-Bold.ttf"))
-    # Tamil
-    pdf.add_font(TAMIL_REGULAR, REGULAR, str(FONT_DIR / "NotoSansTamil-Regular.ttf"))
-    pdf.add_font(TAMIL_REGULAR, BOLD, str(FONT_DIR / "NotoSansTamil-Bold.ttf"))
-    # Bengali
-    pdf.add_font(
-        BENGALI_REGULAR, REGULAR, str(FONT_DIR / "NotoSansBengali-Regular.ttf")
-    )
-    pdf.add_font(BENGALI_REGULAR, BOLD, str(FONT_DIR / "NotoSansBengali-Bold.ttf"))
-    # Arabic (covers ar + fa — Persian uses the Arabic script)
-    pdf.add_font(ARABIC_REGULAR, REGULAR, str(FONT_DIR / "NotoSansArabic-Regular.ttf"))
-    pdf.add_font(ARABIC_REGULAR, BOLD, str(FONT_DIR / "NotoSansArabic-Bold.ttf"))
-    # Hebrew
-    pdf.add_font(HEBREW_REGULAR, REGULAR, str(FONT_DIR / "NotoSansHebrew-Regular.ttf"))
-    pdf.add_font(HEBREW_REGULAR, BOLD, str(FONT_DIR / "NotoSansHebrew-Bold.ttf"))
-    # Simplified Chinese — alias Regular under both keys (no bold .otf shipped)
-    pdf.add_font(SC_REGULAR, REGULAR, str(FONT_DIR / "NotoSansSC-Regular.otf"))
-    pdf.add_font(SC_REGULAR, BOLD, str(FONT_DIR / "NotoSansSC-Regular.otf"))
-    # Japanese — same single-weight pattern
-    pdf.add_font(JP_REGULAR, REGULAR, str(FONT_DIR / "NotoSansJP-Regular.otf"))
-    pdf.add_font(JP_REGULAR, BOLD, str(FONT_DIR / "NotoSansJP-Regular.otf"))
-    pdf.set_text_shaping(use_shaping_engine=True)
-    pdf._panchanga_flags = getattr(pdf, "_panchanga_flags", set()) | {"noto-registered"}
+    DEV_REGULAR: {
+        REGULAR: "NotoSansDevanagari-Regular.ttf",
+        BOLD: "NotoSansDevanagari-Bold.ttf",
+    },
+    TAMIL_REGULAR: {
+        REGULAR: "NotoSansTamil-Regular.ttf",
+        BOLD: "NotoSansTamil-Bold.ttf",
+    },
+    BENGALI_REGULAR: {
+        REGULAR: "NotoSansBengali-Regular.ttf",
+        BOLD: "NotoSansBengali-Bold.ttf",
+    },
+    # Arabic (covers ar + fa - Persian uses the Arabic script)
+    ARABIC_REGULAR: {
+        REGULAR: "NotoSansArabic-Regular.ttf",
+        BOLD: "NotoSansArabic-Bold.ttf",
+    },
+    HEBREW_REGULAR: {
+        REGULAR: "NotoSansHebrew-Regular.ttf",
+        BOLD: "NotoSansHebrew-Bold.ttf",
+    },
+    SC_REGULAR: {REGULAR: "NotoSansSC-Regular.otf", BOLD: "NotoSansSC-Regular.otf"},
+    JP_REGULAR: {REGULAR: "NotoSansJP-Regular.otf", BOLD: "NotoSansJP-Regular.otf"},
+}
+
+# Scripts that render wrongly without HarfBuzz (conjunct formation, matra
+# reordering, cursive joining, bidi). Latin/Cyrillic/CJK are correct without
+# the shaping engine, and skipping it saves ~1s on a Latin-only report.
+_SHAPED_FAMILIES = {
+    DEV_REGULAR,
+    TAMIL_REGULAR,
+    BENGALI_REGULAR,
+    ARABIC_REGULAR,
+    HEBREW_REGULAR,
+}
+
+
+def ensure_family(pdf: FPDF, family: str) -> None:
+    """Register `family`'s faces on `pdf` if not already done (lazy add_font)."""
+    flags = getattr(pdf, "_panchanga_flags", set())
+    key = f"font:{family}"
+    if key in flags:
+        return
+    for style, fname in FONT_FILES[family].items():
+        pdf.add_font(family, style, str(FONT_DIR / fname))
+    pdf._panchanga_flags = flags | {key}
+
+
+def _set_run_font(pdf: FPDF, family: str, style: str, size: float) -> None:
+    """set_font plus lazy registration plus per-script shaping toggle."""
+    ensure_family(pdf, family)
+    pdf.set_text_shaping(use_shaping_engine=family in _SHAPED_FAMILIES)
+    pdf.set_font(family, style, size)
+
+
+def register_fonts(pdf: FPDF) -> None:
+    """Prepare `pdf` for script-aware text. Idempotent.
+
+    Only NotoSans (Latin + Cyrillic) is registered eagerly - it appears on
+    every page. The other seven families are parsed lazily by draw_text /
+    text_width the first time a run of their script shows up, so an
+    English-only report never pays for Devanagari/CJK font parsing.
+    """
+    ensure_family(pdf, LATIN_REGULAR)
 
 
 def is_devanagari(text: str) -> bool:
@@ -170,7 +208,7 @@ def text_width(pdf: FPDF, text: str, family: str, style: str, size: float) -> fl
     draw_text will actually render the string."""
     total = 0.0
     for fam, seg in _split_runs(text, "en"):
-        pdf.set_font(fam, style, size)
+        _set_run_font(pdf, fam, style, size)
         total += _run_width(pdf, seg, size)
     return total
 
@@ -231,7 +269,7 @@ def draw_text(
 
     widths = []
     for fam, seg in runs:
-        pdf.set_font(fam, style, size)
+        _set_run_font(pdf, fam, style, size)
         widths.append(_run_width(pdf, seg, size))
     total_width = sum(widths)
 
@@ -246,7 +284,7 @@ def draw_text(
     cursor = x
     try:
         for (fam, seg), seg_width in zip(runs, widths):
-            pdf.set_font(fam, style, size)
+            _set_run_font(pdf, fam, style, size)
             pdf.set_xy(cursor, y - 0.8 * size)
             # w=0 would mean "extend to the right margin" to cell(); None
             # makes it size the cell to the (shaped) text itself.

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,5 +1,8 @@
 import logging
+import multiprocessing
 import os
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal, Optional
@@ -407,6 +410,36 @@ class PrintPdfRequest(BaseModel):
     chart_style: Optional[Literal["north", "south"]] = None
 
 
+# PDF rendering runs in a single-worker process pool, NOT the request
+# threadpool: CPython's specializing interpreter only optimizes bytecode on
+# the main thread, and fpdf2's attribute-heavy render is exactly the code
+# that benefits - the same render measures ~0.5s on a main thread vs ~1.1s
+# on a FastAPI threadpool thread. The pool child renders on its own main
+# thread. "spawn" (not fork) keeps the child clean of the parent's event
+# loop; it imports pdf.report lazily on first use (~1s warmup, once).
+_pdf_pool: Optional[ProcessPoolExecutor] = None
+
+
+def _get_pdf_pool() -> ProcessPoolExecutor:
+    global _pdf_pool
+    if _pdf_pool is None:
+        _pdf_pool = ProcessPoolExecutor(
+            max_workers=1, mp_context=multiprocessing.get_context("spawn")
+        )
+    return _pdf_pool
+
+
+def _render_pdf_in_pool(**kwargs) -> bytes:
+    global _pdf_pool
+    try:
+        return _get_pdf_pool().submit(render_pdf, **kwargs).result(timeout=60)
+    except BrokenProcessPool:
+        # Pool child died (OOM kill, etc.) - replace it and retry once.
+        logging.warning("PDF process pool broken, restarting it")
+        _pdf_pool = None
+        return _get_pdf_pool().submit(render_pdf, **kwargs).result(timeout=60)
+
+
 @api_router.post("/print-pdf")
 def print_pdf(req: PrintPdfRequest):
     """Render the Traditional one-page PDF for the given birth details and
@@ -435,7 +468,7 @@ def print_pdf(req: PrintPdfRequest):
             longitude=req.longitude,
             timezone_name=req.timezone,
         )
-        pdf_bytes = render_pdf(
+        pdf_bytes = _render_pdf_in_pool(
             name=req.name or "",
             sex=req.sex or "Male",
             chart_data=chart_data,
@@ -482,6 +515,9 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
+# fontTools emits ~200 INFO lines per PDF font subset; at INFO level that
+# floods the journal and adds ~0.6s of log formatting per /api/print-pdf.
+logging.getLogger("fontTools").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 # Prometheus application metrics. Exposed at /metrics (not under /api, so Nginx


### PR DESCRIPTION
Three independent fixes for /api/print-pdf (was ~2.4s per request):

- Lazy font registration: parse a Noto face with fontTools only when a text run actually needs its script, instead of all 8 families per render (>1s). English reports now parse just NotoSans.
- Per-script HarfBuzz shaping: enable the shaping engine only for Devanagari/Tamil/Bengali/Arabic/Hebrew runs. Latin/Cyrillic/CJK render identically without it and skip ~1s of shaping plus bidi preprocessing.
- Render in a single-worker spawn ProcessPoolExecutor: CPython 3.13's specializing interpreter only optimizes bytecode on the main thread, so the same render costs 0.53s on a main thread but 1.1s on a FastAPI threadpool thread. The pool child renders on its own main thread.

Also silence fontTools' ~200 INFO lines per font subset that flooded the journal on every PDF request.

Measured warm via the API: en 2.4s -> 0.52s, hi ~2.4s -> 1.26s. Verified hi/ta/ar shaping visually (conjuncts, matras, joining intact); 256 backend tests pass.